### PR TITLE
feat: Disable ads and analytics on localhost

### DIFF
--- a/layouts/partials/analytics.html
+++ b/layouts/partials/analytics.html
@@ -1,0 +1,34 @@
+{{ if hugo.IsProduction }}
+  {{ if and .Site.Params.clarity.enabled }}
+  <script type="text/javascript">
+      (function(c,l,a,r,i,t,y){
+          c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+          t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+          y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+      })(window, document, "clarity", "script", "{{ .Site.Params.umami.jsLocation }}");
+  </script>
+  {{ end }}
+
+
+  {{/* Add support for umami website analytics */}}
+  {{ if and .Site.Params.umami.enabled }}
+  <script
+    async
+    defer
+    data-website-id="{{ .Site.Params.umami.websiteId }}"
+    src="{{ .Site.Params.umami.jsLocation }}"
+  ></script>
+  {{ end }}
+
+
+  {{ if and .Site.Params.posthog.enabled }}
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init Ie Ts Ms Ee Es Rs capture Ge calculateEventProperties Os register register_once register_for_session unregister unregister_for_session js getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty Ds Fs createPersonProfile Ls Ps opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing Cs debug I As getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+    posthog.init("{{ .Site.Params.posthog.id }}", {
+        api_host: 'https://us.i.posthog.com',
+        defaults: '2025-05-24',
+        person_profiles: 'identified_only', // or 'always' to create profiles for anonymous users as well
+    })
+  </script>
+  {{ end }}
+{{ end }}

--- a/layouts/partials/carbonads.html
+++ b/layouts/partials/carbonads.html
@@ -1,3 +1,4 @@
+{{ if hugo.IsProduction }}
 <style>
     /* Container for Carbon Ads */
     #carbon-container {
@@ -240,3 +241,4 @@
     }
 })();
 </script>
+{{ end }}


### PR DESCRIPTION
This change prevents ads and analytics from loading in non-production environments (e.g., when running `hugo server`).

- Overrode the theme's `analytics.html` partial to wrap analytics scripts in a `hugo.IsProduction` check.
- Modified the `carbonads.html` partial to wrap the ad script in a `hugo.IsProduction` check.