### PR TITLE
Add slug routing for individual tags

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -16,11 +16,12 @@ timeZone = "Asia/Kolkata"
 enableRobotsTXT = true
 
 # Generate "Bearblog"-like URLs !only!, see https://bearblog.dev/.
-disableKinds = ["taxonomy"]
-ignoreErrors = ["error-disable-taxonomy"]
+[taxonomies]
+  tag = "tags"
+
 [permalinks]
   blog = "/blog/:slug/"
-  tags = "/blog/:slug"
+  tags = "/tags/:slug/"
 
 [params]
   # The "description" of your website. This is used in the meta data of your generated html.


### PR DESCRIPTION
Previously, taxonomies were completely disabled via disableKinds = ["taxonomy"], which prevented tag pages from being generated. This commit:
- Removes the disableKinds configuration that was blocking taxonomy pages
- Adds proper taxonomy configuration for tags
- Sets tag permalinks to use /tags/:slug/ format

This enables proper tag routing with the /tags prefix as expected.