### PR TITLE
Fix broken link in grep-app-mcp post

### DIFF
--- a/content/blog/2025-07/25-grep-app-mcp.md
+++ b/content/blog/2025-07/25-grep-app-mcp.md
@@ -16,11 +16,7 @@ Even in GitHub it takes more time than that.
 
 I usually use this tool to have a look at how others are using particular feature/method from library. 
 
-Now they support Remote MCP which can be accessed here
-
-```
-https://mcp.grep.app
-```
+Now they support Remote MCP which can be accessed [here](https://mcp.grep.app)
 
 ## How to setup?
 


### PR DESCRIPTION
Updated content/blog/2025-07/25-grep-app-mcp.md to use a proper markdown link for mcp.grep.app instead of a code block.

---
*PR created automatically by Jules for task [6673395542869581420](https://jules.google.com/task/6673395542869581420) started by @AshikNesin*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the mcp.grep.app link in the grep-app-mcp blog post. Replaces a fenced code block with a proper markdown link so the URL is clickable.

<sup>Written for commit 7fb0c07ef53ea1ce9c443f2742abf04b088f3dc0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

