### PR TITLE
Fix link formatting in blog posts

### DIFF
--- a/content/blog/2024-12/state-ai-2024.md
+++ b/content/blog/2024-12/state-ai-2024.md
@@ -13,4 +13,4 @@ draft: true
 
 
 ## References
-- https://x.com/saranormous/status/1866933642401886707
+- [https://x.com/saranormous/status/1866933642401886707](https://x.com/saranormous/status/1866933642401886707)

--- a/content/blog/2025-01/01-llm-in-2024.md
+++ b/content/blog/2025-01/01-llm-in-2024.md
@@ -34,5 +34,5 @@ Here are some of the notable progress. It's primarily based on the summary writt
 	- Apps like Bolt.new, Vercel's v0, etc becoming more and more popular
 ## References
 - [Things we learned about LLMs in 2024](https://simonwillison.net/2024/Dec/31/llms-in-2024/)
-- https://huggingface.co/spaces/reach-vb/2024-ai-timeline
-- https://genai2024.replit.app/
+- [https://huggingface.co/spaces/reach-vb/2024-ai-timeline](https://huggingface.co/spaces/reach-vb/2024-ai-timeline)
+- [https://genai2024.replit.app/](https://genai2024.replit.app/)

--- a/content/blog/2025-01/03-tool-use.md
+++ b/content/blog/2025-01/03-tool-use.md
@@ -8,7 +8,7 @@ draft: true
 ---
 
 ## Reference
-- https://docs.anthropic.com/en/docs/build-with-claude/tool-use
-- https://platform.openai.com/docs/guides/function-calling
-- https://www.promptingguide.ai/applications/function_calling
-- https://docs.mistral.ai/capabilities/function_calling/
+- [https://docs.anthropic.com/en/docs/build-with-claude/tool-use](https://docs.anthropic.com/en/docs/build-with-claude/tool-use)
+- [https://platform.openai.com/docs/guides/function-calling](https://platform.openai.com/docs/guides/function-calling)
+- [https://www.promptingguide.ai/applications/function_calling](https://www.promptingguide.ai/applications/function_calling)
+- [https://docs.mistral.ai/capabilities/function_calling/](https://docs.mistral.ai/capabilities/function_calling/)

--- a/content/blog/2025-01/04-ai-platform-engineering-patrick-debois-talk.md
+++ b/content/blog/2025-01/04-ai-platform-engineering-patrick-debois-talk.md
@@ -9,5 +9,5 @@ url: blog/ai-platform-engineering-patrick-debois-talk
 via_url: https://www.youtube.com/watch?v=5qNXdLbEdew&ab_channel=AIEngineer
 draft: true
 ---
-https://www.youtube.com/watch?v=sPXwz4DWu0o&ab_channel=PatrickDebois
+[https://www.youtube.com/watch?v=sPXwz4DWu0o&ab_channel=PatrickDebois](https://www.youtube.com/watch?v=sPXwz4DWu0o&ab_channel=PatrickDebois)
 

--- a/content/blog/2025-01/28-open-source-alternatives-openai-operator.md
+++ b/content/blog/2025-01/28-open-source-alternatives-openai-operator.md
@@ -123,7 +123,7 @@ Here's the formatted markdown:
 
 The video demo in the blog post is from these Tweets
 
-- https://x.com/pk_iv/status/1882837641521221858
-- https://x.com/addyosmani/status/1878245455223767314
+- [https://x.com/pk_iv/status/1882837641521221858](https://x.com/pk_iv/status/1882837641521221858)
+- [https://x.com/addyosmani/status/1878245455223767314](https://x.com/addyosmani/status/1878245455223767314)
 
 Happy automating browser!

--- a/content/blog/2025-05/26-zerodha-mcp.md
+++ b/content/blog/2025-05/26-zerodha-mcp.md
@@ -19,7 +19,7 @@ Here is a quick demo by them
 https://mcp.kite.trade/sse
 ```
 ### References
-- https://zerodha.com/z-connect/featured/connect-your-zerodha-account-to-ai-assistants-with-kite-mcp
-- https://www.youtube.com/watch?v=dA6IgCdg6tE
+- [https://zerodha.com/z-connect/featured/connect-your-zerodha-account-to-ai-assistants-with-kite-mcp](https://zerodha.com/z-connect/featured/connect-your-zerodha-account-to-ai-assistants-with-kite-mcp)
+- [https://www.youtube.com/watch?v=dA6IgCdg6tE](https://www.youtube.com/watch?v=dA6IgCdg6tE)
 
 Happy building apps!

--- a/content/blog/2025-05/27-github-mcp-vulnerability.md
+++ b/content/blog/2025-05/27-github-mcp-vulnerability.md
@@ -31,7 +31,7 @@ When using/building/experimenting with  MCP, we need to be mindful of the attack
 ## Credits
 - [Invariantlabs.ai](https://invariantlabs.ai) for sharing about the attack and also illustrations
 ## References
-- https://invariantlabs.ai/blog/mcp-github-vulnerability
-- https://simonwillison.net/2025/May/26/github-mcp-exploited/
+- [https://invariantlabs.ai/blog/mcp-github-vulnerability](https://invariantlabs.ai/blog/mcp-github-vulnerability)
+- [https://simonwillison.net/2025/May/26/github-mcp-exploited/](https://simonwillison.net/2025/May/26/github-mcp-exploited/)
 
 Happy building apps!

--- a/content/blog/2025-05/31-ai-trends-report-bond-capital.md
+++ b/content/blog/2025-05/31-ai-trends-report-bond-capital.md
@@ -10,14 +10,14 @@ via_url:
 ---
 I came across AI Trends report (state of AI) by by BOND Capital. 340 slides  🤯 
 
-👉 https://www.bondcap.com/reports/tai
+👉 [https://www.bondcap.com/reports/tai](https://www.bondcap.com/reports/tai)
 
 Here are some of takeaways/summary from the report:
-- https://x.com/Rahul_J_Mathur/status/1929115989871915299
-- https://x.com/jasonlk/status/1929276325681848585
+- [https://x.com/Rahul_J_Mathur/status/1929115989871915299](https://x.com/Rahul_J_Mathur/status/1929115989871915299)
+- [https://x.com/jasonlk/status/1929276325681848585](https://x.com/jasonlk/status/1929276325681848585)
 
 *Side note: I'm yet to read it completely. Will add my notes once I'm done with it.*
 ## References
-- https://news.smol.ai/issues/25-05-30-mary-meeker/
+- [https://news.smol.ai/issues/25-05-30-mary-meeker/](https://news.smol.ai/issues/25-05-30-mary-meeker/)
 
 Happy reading reports!

--- a/content/blog/2025-06/01-llm-snitching.md
+++ b/content/blog/2025-06/01-llm-snitching.md
@@ -8,7 +8,7 @@ via_url:
 ---
 I came across a fun benchmark by [Theo Browne](https://t3.gg/) where he shows tries to see if a AI model can **rat you** out to authorities if you told it to **take initiative** in enforcing its morals values while exposing the evidence of wrongdoing.
 
-👉 https://simonwillison.net/2025/May/31/snitchbench-with-llm/
+👉 [https://simonwillison.net/2025/May/31/snitchbench-with-llm/](https://simonwillison.net/2025/May/31/snitchbench-with-llm/)
 
 Basically, the AI app has access to send emails. When it finds any morally wrong thing, it sends email to authorities/news outlets with evidences.
 
@@ -29,8 +29,8 @@ This is the email it tied to send when [Simon Willison](https://simonwillison.ne
 > Whereas this kind of ethical intervention and whistleblowing is perhaps appropriate in principle, it has a risk of misfiring if users give Opus-based agents access to incomplete or misleading information and prompt them in these ways. **We recommend that users exercise caution with instructions like these that invite high-agency behavior in contexts that could appear ethically questionable.**
 
 ## References
-- https://snitchscript-visualized.vercel.app/
-- https://github.com/t3dotgg/SnitchBench
-- https://simonwillison.net/2025/May/31/snitchbench-with-llm/
+- [https://snitchscript-visualized.vercel.app/](https://snitchscript-visualized.vercel.app/)
+- [https://github.com/t3dotgg/SnitchBench](https://github.com/t3dotgg/SnitchBench)
+- [https://simonwillison.net/2025/May/31/snitchbench-with-llm/](https://simonwillison.net/2025/May/31/snitchbench-with-llm/)
 
 Happy role-playing!

--- a/content/blog/2025-06/02-anthropic-claude-4-system-card.md
+++ b/content/blog/2025-06/02-anthropic-claude-4-system-card.md
@@ -10,13 +10,13 @@ via_url: https://simonwillison.net/2025/May/25/claude-4-system-card/
 ---
 I came across highlights of **System Card** for Anthropic Claude 4 models by [Simon Willison](https://simonwillison.net) 
 
-👉 https://simonwillison.net/2025/May/25/claude-4-system-card/
+👉 [https://simonwillison.net/2025/May/25/claude-4-system-card/](https://simonwillison.net/2025/May/25/claude-4-system-card/)
 
 ## What is System Card?
 A system card (in the context of AI) is a detailed documentation or report by AI company that provide detailed overview of an AI **system's architecture, capabilities, limitations, and safety evaluations**
 
 ## References
-- https://simonwillison.net/2025/May/25/claude-4-system-card/
-- https://www-cdn.anthropic.com/4263b940cabb546aa0e3283f35b686f4f3b2ff47.pdf
+- [https://simonwillison.net/2025/May/25/claude-4-system-card/](https://simonwillison.net/2025/May/25/claude-4-system-card/)
+- [https://www-cdn.anthropic.com/4263b940cabb546aa0e3283f35b686f4f3b2ff47.pdf](https://www-cdn.anthropic.com/4263b940cabb546aa0e3283f35b686f4f3b2ff47.pdf)
 
 Happy reading reports!

--- a/content/blog/2025-06/03-anthropic-claude-code-execution-tool.md
+++ b/content/blog/2025-06/03-anthropic-claude-code-execution-tool.md
@@ -171,6 +171,6 @@ You can read more about containers, pre-installed libraries, file handling in th
 - With features like these AI companies are slowly becoming platform. And inevitability vendor lock-in comes into the picture. 
 - And yeah, for production application it would be better to build this feature on top of providers like https://modal.com that will give us more control like having access to internet, installing custom package, etc.
 ## References
-- https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/code-execution-tool
+- [https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/code-execution-tool](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/code-execution-tool)
 
 Happy code execution!

--- a/content/blog/2025-06/04-anthropic-claude-web-search-tool.md
+++ b/content/blog/2025-06/04-anthropic-claude-web-search-tool.md
@@ -332,6 +332,6 @@ There models supports web search tool:
 ```
 
 ## References
-- https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/web-search-tool
+- [https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/web-search-tool](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/web-search-tool)
 
 Happy searching internet!

--- a/content/blog/2025-06/05-cursor-mcp-deeplink.md
+++ b/content/blog/2025-06/05-cursor-mcp-deeplink.md
@@ -35,6 +35,6 @@ In their [website](https://docs.cursor.com/deeplinks#generate-install-link), you
 
 And it'll generate the snippet / link which you can use to directly install your MCP
 ## References
-- https://docs.cursor.com/context/model-context-protocol
+- [https://docs.cursor.com/context/model-context-protocol](https://docs.cursor.com/context/model-context-protocol)
 
 Happy directly installing!

--- a/content/blog/2025-06/06-cursor-v1.md
+++ b/content/blog/2025-06/06-cursor-v1.md
@@ -40,8 +40,8 @@ Memories are stored per project on an individual level, and can be managed from 
 - Support for Mermaid diagrams and Markdown tables 
 
 ## References
-- https://www.cursor.com/changelog/1-0
+- [https://www.cursor.com/changelog/1-0](https://www.cursor.com/changelog/1-0)
 - [Cursor is finally out of beta? 👀👀](https://www.youtube.com/watch?v=NDYLKkd0_mc) 
-- https://youtu.be/Ig-cfiqWJCs
+- [https://youtu.be/Ig-cfiqWJCs](https://youtu.be/Ig-cfiqWJCs)
 
 Happy updating cursor!

--- a/content/blog/2025-06/08-llm-interview-questions-by-hao-hoang.md
+++ b/content/blog/2025-06/08-llm-interview-questions-by-hao-hoang.md
@@ -15,6 +15,6 @@ It looks pretty insightful 👇
 
 ![2025-06-08 at 08.48.42@2x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/images/2025-06/2025-06-08-at-08.48.42-at-2x.png)
 
-https://drive.google.com/file/d/1cUxKspEXgQ64s4OFEw0kabf_qNauOPiH/view
+[https://drive.google.com/file/d/1cUxKspEXgQ64s4OFEw0kabf_qNauOPiH/view](https://drive.google.com/file/d/1cUxKspEXgQ64s4OFEw0kabf_qNauOPiH/view)
 
 Happy learning AI!

--- a/content/blog/2025-06/10-openai-web-search-tool.md
+++ b/content/blog/2025-06/10-openai-web-search-tool.md
@@ -215,6 +215,6 @@ You will get token usage in API response.
 You can also do [domain level filtering](/blog/domain-filter-openai-web-search-tool/) as well when performing web search.
 
 ## References
-- https://platform.openai.com/docs/guides/tools-web-search?api-mode=responses&lang=curl
+- [https://platform.openai.com/docs/guides/tools-web-search?api-mode=responses&lang=curl](https://platform.openai.com/docs/guides/tools-web-search?api-mode=responses&lang=curl)
 
 Happy searching internet!

--- a/content/blog/2025-06/11-anthropic-remote-mcp.md
+++ b/content/blog/2025-06/11-anthropic-remote-mcp.md
@@ -193,6 +193,6 @@ Make sure to set you `ANTHROPIC_API_KEY` in header
 We got the correct response -- it invoked the mcp tools got some responses from Zerodha MCP server. Their MCP server requires users to manually open the link and verify but as a client it worked as expected.
 
 ## References
-- https://docs.anthropic.com/en/docs/agents-and-tools/mcp-connector
+- [https://docs.anthropic.com/en/docs/agents-and-tools/mcp-connector](https://docs.anthropic.com/en/docs/agents-and-tools/mcp-connector)
 
 Happy executing tools!

--- a/content/blog/2025-06/12-practical-guide-to-building-agents-openai.md
+++ b/content/blog/2025-06/12-practical-guide-to-building-agents-openai.md
@@ -12,6 +12,6 @@ If you're building AI Agents using [OpenAI Agents SDK](https://openai.github.io/
 
 You might find OpenAI's official guide on building agents useful 👇
 
-https://cdn.openai.com/business-guides-and-resources/a-practical-guide-to-building-agents.pdf
+[https://cdn.openai.com/business-guides-and-resources/a-practical-guide-to-building-agents.pdf](https://cdn.openai.com/business-guides-and-resources/a-practical-guide-to-building-agents.pdf)
 
 Happy building agents!

--- a/content/blog/2025-06/13-openai-background-mode.md
+++ b/content/blog/2025-06/13-openai-background-mode.md
@@ -107,6 +107,6 @@ curl https://api.openai.com/v1/responses/resp_YOUR_ID_HERE \
 ```
 
 ## References
-- https://platform.openai.com/docs/guides/background
+- [https://platform.openai.com/docs/guides/background](https://platform.openai.com/docs/guides/background)
 
 Happy background mode!

--- a/content/blog/2025-06/14-mcp-for-beginners-microsoft.md
+++ b/content/blog/2025-06/14-mcp-for-beginners-microsoft.md
@@ -17,6 +17,6 @@ And the best part is, unlike other tutorials there is a hands-on examples across
 
 Here you go 👇
 
-https://github.com/microsoft/mcp-for-beginners
+[https://github.com/microsoft/mcp-for-beginners](https://github.com/microsoft/mcp-for-beginners)
 
 Happy building MCP-servers!

--- a/content/blog/2025-06/15-app-build-by-neon.md
+++ b/content/blog/2025-06/15-app-build-by-neon.md
@@ -17,7 +17,7 @@ I haven't played around with it yet but it looks like a good reference if you're
 
 And their blog post covers high level design as well 👇
 
-https://www.app.build/blog/app-build-open-source-ai-agent
+[https://www.app.build/blog/app-build-open-source-ai-agent](https://www.app.build/blog/app-build-open-source-ai-agent)
 
 ## Will I use this?
 I see this as a push from them with the goal of making people other Neon products like database. There is nothing wrong in it. 

--- a/content/blog/2025-06/16-anthropic-claude-code-aws-bedrock.md
+++ b/content/blog/2025-06/16-anthropic-claude-code-aws-bedrock.md
@@ -59,7 +59,7 @@ export ANTHROPIC_MODEL='us.anthropic.claude-opus-4-20250514-v1:0'
 export ANTHROPIC_SMALL_FAST_MODEL='us.anthropic.claude-3-5-haiku-20241022-v1:0'
 ```
 ## References
-- https://docs.anthropic.com/en/docs/claude-code/amazon-bedrock
-- https://community.aws/content/2tXkZKrZzlrlu0KfH8gST5Dkppq/claude-code-on-amazon-bedrock-quick-setup-guide
+- [https://docs.anthropic.com/en/docs/claude-code/amazon-bedrock](https://docs.anthropic.com/en/docs/claude-code/amazon-bedrock)
+- [https://community.aws/content/2tXkZKrZzlrlu0KfH8gST5Dkppq/claude-code-on-amazon-bedrock-quick-setup-guide](https://community.aws/content/2tXkZKrZzlrlu0KfH8gST5Dkppq/claude-code-on-amazon-bedrock-quick-setup-guide)
 
 Happy writing codes!

--- a/content/blog/2025-06/18-llm-pricing-calculator.md
+++ b/content/blog/2025-06/18-llm-pricing-calculator.md
@@ -23,6 +23,6 @@ Just a simple UI that does the job really well 👇
 ![2025-06-18 at 22.45.03@2x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/images/2025-06/2025-06-18-at-22.45.03-at-2x.png)
 Fun fact: He has built this using Claude and you can read the transcript [here](https://claude.ai/share/5e0eebde-6204-4496-aa1a-fcc519df44b2)
 ## References
-- https://simonwillison.net/2025/Apr/10/llm-pricing-calculator/
+- [https://simonwillison.net/2025/Apr/10/llm-pricing-calculator/](https://simonwillison.net/2025/Apr/10/llm-pricing-calculator/)
 
 Happy building apps!

--- a/content/blog/2025-06/19-cloudflare-llm-playground-open-source.md
+++ b/content/blog/2025-06/19-cloudflare-llm-playground-open-source.md
@@ -20,8 +20,8 @@ It takes care of lot of things out of box:
 Just a simple UI that does the job really well 👇
 ![2025-06-19 at 23.26.19@2x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/images/2025-06/2025-06-19-at-23.26.19-at-2x.png)
 ## Source Code
-- https://github.com/cloudflare/ai/tree/main/playground/ai
+- [https://github.com/cloudflare/ai/tree/main/playground/ai](https://github.com/cloudflare/ai/tree/main/playground/ai)
 ## References
-- https://blog.cloudflare.com/connect-any-react-application-to-an-mcp-server-in-three-lines-of-code/
+- [https://blog.cloudflare.com/connect-any-react-application-to-an-mcp-server-in-three-lines-of-code/](https://blog.cloudflare.com/connect-any-react-application-to-an-mcp-server-in-three-lines-of-code/)
 
 Happy building apps!

--- a/content/blog/2025-06/20-use-mcp-react-hook.md
+++ b/content/blog/2025-06/20-use-mcp-react-hook.md
@@ -89,8 +89,8 @@ Here is an [example](https://inspector.use-mcp.dev/) of showcasing the capabilit
 ![2025-06-20 at 21.49.38@2x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/images/2025-06/2025-06-20-at-21.49.38-at-2x.png)
 
 ## Source Code
-- https://github.com/modelcontextprotocol/use-mcp (MIT)
+- [https://github.com/modelcontextprotocol/use-mcp](https://github.com/modelcontextprotocol/use-mcp) (MIT)
 ## References
-- https://blog.cloudflare.com/connect-any-react-application-to-an-mcp-server-in-three-lines-of-code/
+- [https://blog.cloudflare.com/connect-any-react-application-to-an-mcp-server-in-three-lines-of-code/](https://blog.cloudflare.com/connect-any-react-application-to-an-mcp-server-in-three-lines-of-code/)
 
 Happy building apps!

--- a/content/blog/2025-06/21-claude-code-remote-mcp.md
+++ b/content/blog/2025-06/21-claude-code-remote-mcp.md
@@ -19,7 +19,7 @@ Just imagine — you say a query like _"Fix bug-x"_, and it fetches the bug deta
 
 How cool is that? 🤯
 
-👉 https://x.com/AnthropicAI/status/1935367951542280239
+👉 [https://x.com/AnthropicAI/status/1935367951542280239](https://x.com/AnthropicAI/status/1935367951542280239)
 
 {{< video "https://res.cloudinary.com/ashiknesin/video/upload/AIEngineeringGuide.com/static/claude-code-remote-mcp.mp4"  >}}
 

--- a/content/blog/2025-06/22-software-is-changing-again-andrej-karpathy.md
+++ b/content/blog/2025-06/22-software-is-changing-again-andrej-karpathy.md
@@ -121,8 +121,8 @@ Code is actually easy part!
 
 ![2025-06-22 at 20.17.25@2x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/images/2025-06/2025-06-22-at-20.17.25-at-2x.png)
 ## Resources
-- https://drive.google.com/file/d/1a0h1mkwfmV2PlekxDN8isMrDA5evc4wW/view
-- https://x.com/gregisenberg/status/1935776270329298965/photo/2
+- [https://drive.google.com/file/d/1a0h1mkwfmV2PlekxDN8isMrDA5evc4wW/view](https://drive.google.com/file/d/1a0h1mkwfmV2PlekxDN8isMrDA5evc4wW/view)
+- [https://x.com/gregisenberg/status/1935776270329298965/photo/2](https://x.com/gregisenberg/status/1935776270329298965/photo/2)
 
 
 

--- a/content/blog/2025-06/23-cluely-system-prompt-leak.md
+++ b/content/blog/2025-06/23-cluely-system-prompt-leak.md
@@ -19,6 +19,6 @@ Fun fact: The founders initially have built [tool](https://www.interviewcoder.co
 ## Disclaimer
 I'm not sure if it's 100% correct. I saw this in Twitter and bookmarking here in the blog for future reference. 
 ## Credits
-- https://x.com/jackhcable/status/1936500980297932827
+- [https://x.com/jackhcable/status/1936500980297932827](https://x.com/jackhcable/status/1936500980297932827)
 
 Happy learning prompts!

--- a/content/blog/2025-06/24-claude-code-vs-code.md
+++ b/content/blog/2025-06/24-claude-code-vs-code.md
@@ -20,6 +20,6 @@ At the moment, it has support for the following:
 
 To be honest, these features are pretty simple one and I believe it is more of like baseline rather than a solid state.
 
-👉 https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code
+👉 [https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code)
 
 Happy building apps!

--- a/content/blog/2025-06/25-google-gemini-cli.md
+++ b/content/blog/2025-06/25-google-gemini-cli.md
@@ -51,7 +51,7 @@ With it's free usage, Google might potentially try to gain more marketshare.
 
 One thing you should be mindful is that, if you're using free option (login with Google Account), then your data will be used for model training. 
 ## Resources
-- https://blog.google/technology/developers/introducing-gemini-cli-open-source-ai-agent/
-- https://github.com/google-gemini/gemini-cli?tab=readme-ov-file
+- [https://blog.google/technology/developers/introducing-gemini-cli-open-source-ai-agent/](https://blog.google/technology/developers/introducing-gemini-cli-open-source-ai-agent/)
+- [https://github.com/google-gemini/gemini-cli?tab=readme-ov-file](https://github.com/google-gemini/gemini-cli?tab=readme-ov-file)
 
 Happy building apps!

--- a/content/blog/2025-06/26-optimize-openai-transcriptions.md
+++ b/content/blog/2025-06/26-optimize-openai-transcriptions.md
@@ -57,4 +57,4 @@ curl --request POST \
 ```
 
 ## References
-- https://george.mand.is/2025/06/openai-charges-by-the-minute-so-make-the-minutes-shorter/ 🌟
+- [https://george.mand.is/2025/06/openai-charges-by-the-minute-so-make-the-minutes-shorter/](https://george.mand.is/2025/06/openai-charges-by-the-minute-so-make-the-minutes-shorter/) 🌟

--- a/content/blog/2025-06/27-openai-deep-research-api.md
+++ b/content/blog/2025-06/27-openai-deep-research-api.md
@@ -23,14 +23,14 @@ Until recently, the models were only available in ChatGPT but now they're making
 This API might be a good fit for the cases where you want **best** quality output and okay with taking more time.
 
 Here are some official docs for you to get started:
-- https://cookbook.openai.com/examples/deep_research_api/introduction_to_deep_research_api
-- https://cookbook.openai.com/examples/deep_research_api/introduction_to_deep_research_api_agents
+- [https://cookbook.openai.com/examples/deep_research_api/introduction_to_deep_research_api](https://cookbook.openai.com/examples/deep_research_api/introduction_to_deep_research_api)
+- [https://cookbook.openai.com/examples/deep_research_api/introduction_to_deep_research_api_agents](https://cookbook.openai.com/examples/deep_research_api/introduction_to_deep_research_api_agents)
 
 And here are some are highlights mentioned in the tweet replies/blog post
 - Does NOT support chat completion API. Only supports Responses API
 - Beware of the costs associated when using this API 
 
 ## References
-- https://platform.openai.com/docs/guides/deep-research
+- [https://platform.openai.com/docs/guides/deep-research](https://platform.openai.com/docs/guides/deep-research)
 
 Happy building apps!

--- a/content/blog/2025-06/28-openai-webhooks.md
+++ b/content/blog/2025-06/28-openai-webhooks.md
@@ -114,6 +114,6 @@ event = client.webhooks.unwrap(request.data, request.headers, secret=webhook_sec
 Or you can use [standard-webhooks](https://github.com/standard-webhooks/standard-webhooks/tree/main?tab=readme-ov-file#reference-implementations) libraries to do the verification part.
 
 ## References
-- https://platform.openai.com/docs/guides/webhooks
+- [https://platform.openai.com/docs/guides/webhooks](https://platform.openai.com/docs/guides/webhooks)
 
 Happy building apps!

--- a/content/blog/2025-06/29-ai-coding-agent-leaderboard.md
+++ b/content/blog/2025-06/29-ai-coding-agent-leaderboard.md
@@ -46,6 +46,6 @@ And in case, if you want direct link for that (got this from their README)
 ![2025-06-29 at 23.18.51@2x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/images/2025-06/2025-06-29-at-23.18.51-at-2x.png)
 
 ## Source
-- https://github.com/aavetis/PRarena
+- [https://github.com/aavetis/PRarena](https://github.com/aavetis/PRarena)
 
 Happy watching stats!

--- a/content/blog/2025-06/30-rag-vs-agentic-rag.md
+++ b/content/blog/2025-06/30-rag-vs-agentic-rag.md
@@ -39,6 +39,6 @@ Here is a good comparison diagram by ByteByteGo 👇
 ![Pasted image 20250630215752.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/images/2025-06/Pasted-image-20250630215752.png)
 
 ## Reference
-- https://blog.bytebytego.com/p/ep169-rag-vs-agentic-rag
+- [https://blog.bytebytego.com/p/ep169-rag-vs-agentic-rag](https://blog.bytebytego.com/p/ep169-rag-vs-agentic-rag)
 
 Happy Agentic RAG

--- a/content/blog/2025-07/01-vs-code-copilot-chat-extension.md
+++ b/content/blog/2025-07/01-vs-code-copilot-chat-extension.md
@@ -12,7 +12,7 @@ As promised at [Microsoft Build 2025](https://github.com/newsroom/press-releases
 
 As of now, they've open sourced their Chat feature (client) that you see in the VS Code but haven't released auto completion and other things.
 
-👉 https://github.com/microsoft/vscode-copilot-chat
+👉 [https://github.com/microsoft/vscode-copilot-chat](https://github.com/microsoft/vscode-copilot-chat)
 
 <blockquote class="twitter-tweet"><p lang="en" dir="ltr">We promised, we delivered. The GitHub Copilot Chat client for VS Code is now open source under the MIT license. This means, you can:<br><br>🔍 Explore the code on GitHub<br> 🛠️ Open PRs, file issues &amp; contribute<br> 💬 See what prompts/context we send to LLMs<br> 🤖 Use Copilot agent mode to… <a href="https://t.co/aKIUE8Xyfn">https://t.co/aKIUE8Xyfn</a></p>&mdash; Thomas Dohmke (@ashtom) <a href="https://twitter.com/ashtom/status/1939724483448717369?ref_src=twsrc%5Etfw">June 30, 2025</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 

--- a/content/blog/2025-07/02-claude-code-custom-command.md
+++ b/content/blog/2025-07/02-claude-code-custom-command.md
@@ -63,6 +63,6 @@ Here is an example command 👇
 ![Pasted image 20250702231028.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/images/2025-07/Pasted-image-20250702231028.png)
 
 ## References
-- https://docs.anthropic.com/en/docs/claude-code/slash-commands#project-commands
+- [https://docs.anthropic.com/en/docs/claude-code/slash-commands#project-commands](https://docs.anthropic.com/en/docs/claude-code/slash-commands#project-commands)
 
 Happy open sourcing!

--- a/content/blog/2025-07/06-kilocode-vs-code.md
+++ b/content/blog/2025-07/06-kilocode-vs-code.md
@@ -31,7 +31,7 @@ Here is a quick demo by the team
 ## Installation
 You can install this in VS Code (and also any VS Code forks like Cursor, Windsurf, etc)
 
-👉 https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code
+👉 [https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code)
 
 ## Features
 
@@ -51,7 +51,7 @@ Note: Since you'll be paying per usage beware of the token usage when you're usi
 ## Pro Tip
 If you already have GitHub Copilot subscription you can configure and use it Kilo Code instead of providing configuring your LLM provider. 
 
-👉 https://kilocode.ai/docs/providers/vscode-lm
+👉 [https://kilocode.ai/docs/providers/vscode-lm](https://kilocode.ai/docs/providers/vscode-lm)
 ## Fun Fact
 Kilo Code is a fork of [Roo Code](https://roocode.com/) which itself is a fork of [Cline](https://cline.bot/)
 

--- a/content/blog/2025-07/07-kilocode-api.md
+++ b/content/blog/2025-07/07-kilocode-api.md
@@ -16,7 +16,7 @@ While checking the code base for Kilocode provider it seems like they're using [
 
 So essentially, you can **directly invoke API** endpoint like how you would use [OpenRouter API](https://openrouter.ai/docs/api-reference/overview)
 
-Replace `https://openrouter.ai/api/v1` in OpenRouter API endpoint with `https://kilocode.ai/api/openrouter` and pass your API key in the header.
+Replace [https://openrouter.ai/api/v1](https://openrouter.ai/api/v1) in OpenRouter API endpoint with [https://kilocode.ai/api/openrouter](https://kilocode.ai/api/openrouter) and pass your API key in the header.
 
 > Note: As of 2025-11-02, it does not work. And it is agaist their ToS to use the API directly. Thanks @AndresDevvv for calling that out in comments
 

--- a/content/blog/2025-07/20-docker-model-runner.md
+++ b/content/blog/2025-07/20-docker-model-runner.md
@@ -41,7 +41,7 @@ docker model run ai/smollm2:360M-Q4_K_M "Why sky is Blue?"
 
 Just set the base url to 
 
-`http://localhost:12434/engines/v1`
+[http://localhost:12434/engines/v1](http://localhost:12434/engines/v1)
 
 And set the model it as whatever model that you're running. In the above case, it'll be `ai/smollm2:360M-Q4_K_M`
 

--- a/content/blog/2025-07/23-reducing-ai-hallucinations-with-context7.md
+++ b/content/blog/2025-07/23-reducing-ai-hallucinations-with-context7.md
@@ -24,7 +24,7 @@ Basically you can wire this up with your AI IDE like Cursor or anywhere it suppo
 ![2025-07-23 at 21.13.32@2x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/images/2025-07/2025-07-23-at-21.13.32-at-2x.png)
 ## Remote MCP
 
-Their remote MCP is 👉 `https://mcp.context7.com/mcp`
+Their remote MCP is 👉 [https://mcp.context7.com/mcp](https://mcp.context7.com/mcp)
 
 You can refer to their docs on how to set it up for your tool. And yeah, the entire thing is open source - MIT  license.
 

--- a/content/blog/2025-07/27-gemini-cli-within-claude-code.md
+++ b/content/blog/2025-07/27-gemini-cli-within-claude-code.md
@@ -65,6 +65,6 @@ You can refer this gist by Andrew Altimi
 
 If you're using free gemini cli, then your data might be used for training. As they say it, if you're not paying then you're the produce 😜
 ## Similar Approaches 
-- https://x.com/iannuttall/status/1938695506013601802
+- [https://x.com/iannuttall/status/1938695506013601802](https://x.com/iannuttall/status/1938695506013601802)
 
 Happy vibe coding!

--- a/content/blog/2025-07/28-claude-code-sub-agents.md
+++ b/content/blog/2025-07/28-claude-code-sub-agents.md
@@ -91,6 +91,6 @@ Include specific examples of how to fix issues.
 
 ## References
 - [Sub agents - Anthropic](https://docs.anthropic.com/en/docs/claude-code/sub-agents)
-- https://x.com/claude_code/status/1948622899604050063
+- [https://x.com/claude_code/status/1948622899604050063](https://x.com/claude_code/status/1948622899604050063)
 
 Happy creating agents!

--- a/content/blog/2025-08/03-kimi-k2-turbo.md
+++ b/content/blog/2025-08/03-kimi-k2-turbo.md
@@ -22,6 +22,6 @@ And yeah, you pay extra for the speed (currently it is 2x but it'll be increased
 It is available in their [Moonshot AI Platform](https://platform.moonshot.ai)
 
 ## Credits
-https://x.com/kimi_moonshot/status/1951168907131355598
+[https://x.com/kimi_moonshot/status/1951168907131355598](https://x.com/kimi_moonshot/status/1951168907131355598)
 
 Happy faster inference!

--- a/content/blog/2025-08/10-claude-code-token-usage-real-time.md
+++ b/content/blog/2025-08/10-claude-code-token-usage-real-time.md
@@ -39,6 +39,6 @@ That's pretty much it.
 Honestly, Anthropic should have provided this as a first class feature. Maybe they're not doing so for business reasons 🤑
 
 ## Credits
-https://x.com/iannuttall/status/1954272037976842547
+[https://x.com/iannuttall/status/1954272037976842547](https://x.com/iannuttall/status/1954272037976842547)
 
 Happy tracking usage!

--- a/content/blog/2025-08/11-qwen-code-cli-free-tier.md
+++ b/content/blog/2025-08/11-qwen-code-cli-free-tier.md
@@ -33,6 +33,6 @@ As with anything, since we're getting this service for free. They might be train
 And also, their model may fallback to maintain service quality.
 
 ## Reference
-https://x.com/Alibaba_Qwen/status/1953835877555151134
+[https://x.com/Alibaba_Qwen/status/1953835877555151134](https://x.com/Alibaba_Qwen/status/1953835877555151134)
 
 Happy CLI coding!

--- a/content/blog/2025-08/12-groq-code-cli.md
+++ b/content/blog/2025-08/12-groq-code-cli.md
@@ -22,7 +22,7 @@ Currently, it has support for only bare essentials like this
 
 ![2025-08-12 at 23.47.05@2x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/images/2025-08/2025-08-12-at-23.47.05-at-2x.png)
 
-👉 https://github.com/build-with-groq/groq-code-cli
+👉 [https://github.com/build-with-groq/groq-code-cli](https://github.com/build-with-groq/groq-code-cli)
 
 ## How to get started?
 

--- a/content/blog/2025-08/14-open-lovable.md
+++ b/content/blog/2025-08/14-open-lovable.md
@@ -8,7 +8,7 @@ via_url:
 ---
 [Firecrawl](https://www.firecrawl.dev/) team has released **minimal open source** version of  [Lovable.dev](https://lovable.dev/)  using which you can use to build React App.
 
-👉 https://github.com/mendableai/open-lovable
+👉 [https://github.com/mendableai/open-lovable](https://github.com/mendableai/open-lovable)
 
 Under the hood it uses firecrawl for web scraping (obviously!) and [E2B](https://e2b.dev) for running custom code code in a safe, sandbox environment.
 

--- a/content/blog/2025-08/15-google-gemma-3-270m.md
+++ b/content/blog/2025-08/15-google-gemma-3-270m.md
@@ -38,7 +38,7 @@ You can use [Transformer.js](https://huggingface.co/docs/transformers.js) to run
 
 And you can refer to the bed time story demo on how they've implemented it.
 
-https://huggingface.co/spaces/webml-community/bedtime-story-generator/blob/main/src/hooks/useLLM.ts
+[https://huggingface.co/spaces/webml-community/bedtime-story-generator/blob/main/src/hooks/useLLM.ts](https://huggingface.co/spaces/webml-community/bedtime-story-generator/blob/main/src/hooks/useLLM.ts)
 
 ## References
 - [Introducing Gemma 3 270M: The compact model for hyper-efficient AI - Google Developers Blog](https://developers.googleblog.com/en/introducing-gemma-3-270m/)

--- a/content/blog/2025-08/18-openai-coding-with-gpt-5.md
+++ b/content/blog/2025-08/18-openai-coding-with-gpt-5.md
@@ -85,4 +85,4 @@ example:
  ```
 
 ## Reference
-- https://cdn.openai.com/API/docs/gpt-5-for-coding-cheatsheet.pdf
+- [https://cdn.openai.com/API/docs/gpt-5-for-coding-cheatsheet.pdf](https://cdn.openai.com/API/docs/gpt-5-for-coding-cheatsheet.pdf)

--- a/content/blog/2025-08/24-deepseek-llm-in-claude-code.md
+++ b/content/blog/2025-08/24-deepseek-llm-in-claude-code.md
@@ -28,6 +28,6 @@ claude
 Make sure to configure your DeepSeek API key that you get from their [platform](https://platform.deepseek.com).
 
 ## Reference
-- https://api-docs.deepseek.com/guides/anthropic_api
+- [https://api-docs.deepseek.com/guides/anthropic_api](https://api-docs.deepseek.com/guides/anthropic_api)
 
 Happy AI coding!

--- a/content/blog/2025-08/26-xai-grok-2-open-source.md
+++ b/content/blog/2025-08/26-xai-grok-2-open-source.md
@@ -26,6 +26,6 @@ One thing to note is its [restrictive license](https://huggingface.co/xai-org/gr
 > You may not use the Materials, derivatives, or outputs (including generated data) to train, create, or improve any foundational, large language, or general-purpose AI models, except for modifications or fine-tuning of Grok 2 permitted under and in accordance with the terms of this Agreement."
 
 ## Credits
-- https://x.com/rasbt/status/1959643038268920231/photo/1
+- [https://x.com/rasbt/status/1959643038268920231/photo/1](https://x.com/rasbt/status/1959643038268920231/photo/1)
 
 Happy learning AI!

--- a/content/blog/2025-08/27-vercel-ai-gateway.md
+++ b/content/blog/2025-08/27-vercel-ai-gateway.md
@@ -21,7 +21,7 @@ They support wide range of models including latest Anthropic and OpenAI models l
 And there is no specific rate limiting for those models as well.
 ![2025-08-27-at-00.08.172x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/2025-08/okak7nq3h3o9rcnnlpy6)
 
-https://vercel.com/ai-gateway/models
+[https://vercel.com/ai-gateway/models](https://vercel.com/ai-gateway/models)
 
 As you might have noticed, you just need to change **model** to something like `xai/grok-4` or `anthropic/claude-sonnet-4` to use different models.
 ![2025-08-27-at-23.40.102x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/2025-08/tjmybgi0gypkx1pvfecn)
@@ -97,7 +97,7 @@ curl -X POST "https://ai-gateway.vercel.sh/v1/chat/completions" \
 ### Your favorite tool/Library
 As long as your app/tool/library supports OpenAI like API, you can use this AI gateway in it.
 
-Just set baseURL as `https://ai-gateway.vercel.sh/v1`
+Just set baseURL as [https://ai-gateway.vercel.sh/v1](https://ai-gateway.vercel.sh/v1)
 
 And `apiKey` as `$AI_GATEWAY_API_KEY`
 
@@ -109,6 +109,6 @@ Currently, Vercel provides $5 free credits per month (as long as you don't add a
 And you can use that credit for virtually anything
 
 ## Reference
-- https://vercel.com/docs/ai-gateway/getting-started
+- [https://vercel.com/docs/ai-gateway/getting-started](https://vercel.com/docs/ai-gateway/getting-started)
 
 Happy building AI!

--- a/content/blog/2025-08/28-free-openai-gpt-5-api.md
+++ b/content/blog/2025-08/28-free-openai-gpt-5-api.md
@@ -25,7 +25,7 @@ Once you have the key, you can set the base URL and API key in an SDK that suppo
 
 | Setting   | Value                               | Notes                                               |
 |-----------|-------------------------------------|-----------------------------------------------------|
-| baseURL   | `https://ai-gateway.vercel.sh/v1`   | Use this as the API base URL                        |
+| baseURL   | [https://ai-gateway.vercel.sh/v1](https://ai-gateway.vercel.sh/v1)   | Use this as the API base URL                        |
 | apiKey    | `$AI_GATEWAY_API_KEY`               | Replace `AI_GATEWAY_API_KEY` with API Key  |
 
 ## Supported GPT 5 Models

--- a/content/blog/2025-08/29-free-anthropic-sonnet-4-api.md
+++ b/content/blog/2025-08/29-free-anthropic-sonnet-4-api.md
@@ -24,7 +24,7 @@ Once you have the key, you can set the base URL and API key in an SDK that suppo
 
 | Setting   | Value                               | Notes                                               |
 |-----------|-------------------------------------|-----------------------------------------------------|
-| baseURL   | `https://ai-gateway.vercel.sh/v1`   | Use this as the API base URL                        |
+| baseURL   | [https://ai-gateway.vercel.sh/v1](https://ai-gateway.vercel.sh/v1)   | Use this as the API base URL                        |
 | apiKey    | `$AI_GATEWAY_API_KEY`               | Replace `AI_GATEWAY_API_KEY` with your actual key   |
 
 ## Example

--- a/content/blog/2025-08/30-free-anthropic-opus-4-1-api.md
+++ b/content/blog/2025-08/30-free-anthropic-opus-4-1-api.md
@@ -23,7 +23,7 @@ Once you have the key, you can set the base URL and API key in an SDK that suppo
 
 | Setting   | Value                               | Notes                                               |
 |-----------|-------------------------------------|-----------------------------------------------------|
-| baseURL   | `https://ai-gateway.vercel.sh/v1`   | Use this as the API base URL                        |
+| baseURL   | [https://ai-gateway.vercel.sh/v1](https://ai-gateway.vercel.sh/v1)   | Use this as the API base URL                        |
 | apiKey    | `$AI_GATEWAY_API_KEY`               | Replace `AI_GATEWAY_API_KEY` with your actual key   |
 
 ## Example

--- a/content/blog/2025-08/31-free-xai-grok-code-fast-1-api.md
+++ b/content/blog/2025-08/31-free-xai-grok-code-fast-1-api.md
@@ -25,7 +25,7 @@ Once you have the key, you can set the base URL and API key in an SDK that suppo
 
 | Setting   | Value                               | Notes                                               |
 |-----------|-------------------------------------|-----------------------------------------------------|
-| baseURL   | `https://ai-gateway.vercel.sh/v1`   | Use this as the API base URL                        |
+| baseURL   | [https://ai-gateway.vercel.sh/v1](https://ai-gateway.vercel.sh/v1)   | Use this as the API base URL                        |
 | apiKey    | `$AI_GATEWAY_API_KEY`               | Replace `AI_GATEWAY_API_KEY` with your actual key   |
 
 ## Example
@@ -69,6 +69,6 @@ response = client.chat.completions.create(
 ```
 
 ## Reference
-https://docs.x.ai/docs/models/grok-code-fast-1
+[https://docs.x.ai/docs/models/grok-code-fast-1](https://docs.x.ai/docs/models/grok-code-fast-1)
 
 Happy building-with AI!

--- a/content/blog/2025-09/01-openai-gpt-5-api-hidden-prompt.md
+++ b/content/blog/2025-09/01-openai-gpt-5-api-hidden-prompt.md
@@ -42,4 +42,4 @@ And this hidden prompt might lead to unexpected behavior.
 ![image.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/2025-08/sy9mhrhltzr6vsce4pu4)
 
 ## Reference
-- https://simonwillison.net/2025/Aug/15/gpt-5-has-a-hidden-system-prompt/
+- [https://simonwillison.net/2025/Aug/15/gpt-5-has-a-hidden-system-prompt/](https://simonwillison.net/2025/Aug/15/gpt-5-has-a-hidden-system-prompt/)

--- a/content/blog/2025-09/02-chatgpt-on-xcode.md
+++ b/content/blog/2025-09/02-chatgpt-on-xcode.md
@@ -30,7 +30,7 @@ Once you're done you should be able to use it in Xcode editor
 ![2025-09-02-at-23.43.132x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/2025-09/msksafvydw5rayp09pte)
 
 ## Reference
-- https://x.com/OpenAIDevs/status/1961557515331862853
-- https://developer.apple.com/documentation/Xcode/writing-code-with-intelligence-in-xcode
+- [https://x.com/OpenAIDevs/status/1961557515331862853](https://x.com/OpenAIDevs/status/1961557515331862853)
+- [https://developer.apple.com/documentation/Xcode/writing-code-with-intelligence-in-xcode](https://developer.apple.com/documentation/Xcode/writing-code-with-intelligence-in-xcode)
 
 Happy AI-assisted coding

--- a/content/blog/2025-09/04-domain-filter-openai-web-search-tool.md
+++ b/content/blog/2025-09/04-domain-filter-openai-web-search-tool.md
@@ -277,6 +277,6 @@ This feature is really helpful for those who are building some sort of Q&A bot b
 But beware of the cost if you need this feature at scale.
 
 ## Reference
-- https://platform.openai.com/docs/guides/tools-web-search?api-mode=responses&lang=curl#domain-filtering
+- [https://platform.openai.com/docs/guides/tools-web-search?api-mode=responses&lang=curl#domain-filtering](https://platform.openai.com/docs/guides/tools-web-search?api-mode=responses&lang=curl#domain-filtering)
 
 Happy building with-AI!

--- a/content/blog/2025-09/10-official-mcp-registry-by-anthropic.md
+++ b/content/blog/2025-09/10-official-mcp-registry-by-anthropic.md
@@ -86,7 +86,7 @@ You can learn more about authentication, publishing the package, security, etc [
 
 You can access the MCP server-related things in the following endpoints.
 
-**Base URL**: `https://registry.modelcontextprotocol.io/v0/servers`
+**Base URL**: [https://registry.modelcontextprotocol.io/v0/servers](https://registry.modelcontextprotocol.io/v0/servers)
 
 ### Server Endpoints
 

--- a/content/blog/2025-09/11-mcp-support-chatgpt.md
+++ b/content/blog/2025-09/11-mcp-support-chatgpt.md
@@ -20,7 +20,7 @@ Here is the video by OpenAI Team on how to setup & use it 👇
 KCD also has a really good [video](https://www.youtube.com/watch?v=_r8XW8Sz_gY) about it where he is using his blog's MCP to perform certain actions.
 
 ## Reference
-- https://x.com/OpenAIDevs/status/1965807401745207708
-- https://platform.openai.com/docs/guides/developer-mode
+- [https://x.com/OpenAIDevs/status/1965807401745207708](https://x.com/OpenAIDevs/status/1965807401745207708)
+- [https://platform.openai.com/docs/guides/developer-mode](https://platform.openai.com/docs/guides/developer-mode)
 
 Happy chatting-with MCP!

--- a/content/blog/2025-09/12-agents-md-vs-code-support.md
+++ b/content/blog/2025-09/12-agents-md-vs-code-support.md
@@ -22,6 +22,6 @@ Recently, VS Code (v1.104+) started supporting that as well.
 With support for a common file for AI Agents, we can avoid creating multiple files for every single AI Agent.
 
 ## Reference
-https://x.com/code/status/1966145747566375215
+[https://x.com/code/status/1966145747566375215](https://x.com/code/status/1966145747566375215)
 
 Happy guiding agents!

--- a/content/blog/2025-09/13-aws-bedrock-llm-with-api-key.md
+++ b/content/blog/2025-09/13-aws-bedrock-llm-with-api-key.md
@@ -15,7 +15,7 @@ Before, you needed to configure IAM credentials and other things, which was kind
 ## How to get started?
 In your AWS Bedrock dashboard, you can find a new option to generate the key.
 
-https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/api-keys
+[https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/api-keys](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/api-keys)
 
 ![2025-09-13-at-23.41.292x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/2025-09/xq0rahfkitgynwf7ig54)
 

--- a/content/blog/2025-09/15-openai-codex-with-z-ai.md
+++ b/content/blog/2025-09/15-openai-codex-with-z-ai.md
@@ -70,6 +70,6 @@ And that will start the codex with the GLM 4.6 model from Z.ai
 ![2025-09-15-at-23.33.512x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/2025-09/upujphhjhp7zrb37p0d1)
 
 ## Reference
-https://github.com/openai/codex/blob/main/docs/config.md
+[https://github.com/openai/codex/blob/main/docs/config.md](https://github.com/openai/codex/blob/main/docs/config.md)
 
 Happy AI-assisted coding!

--- a/content/blog/2025-09/16-github-mcp-marketplace.md
+++ b/content/blog/2025-09/16-github-mcp-marketplace.md
@@ -22,6 +22,6 @@ VS Code might have first-class support for installing MCP powered by this market
 ![2025-09-16-at-23.31.012x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/2025-09/aw4ny1gkbtygyhw4d5sb)
 
 ## Reference
-https://x.com/kentcdodds/status/1968000512294531292
+[https://x.com/kentcdodds/status/1968000512294531292](https://x.com/kentcdodds/status/1968000512294531292)
 
 Happy using MCPs!

--- a/content/blog/2025-09/17-addy-osmani-context-engineering.md
+++ b/content/blog/2025-09/17-addy-osmani-context-engineering.md
@@ -17,4 +17,4 @@ It's pretty good. And it's a good intro to understand what context engineering i
 {{< video "https://video.twimg.com/amplify_video/1966750993917603840/vid/avc1/1920x1080/UQ67XtGeB21QhG4y.mp4"  >}}
 
 ## Credits
-https://x.com/addyosmani/status/1966752236249202743
+[https://x.com/addyosmani/status/1966752236249202743](https://x.com/addyosmani/status/1966752236249202743)

--- a/content/blog/2025-09/21-disable-co-author-in-claude-code.md
+++ b/content/blog/2025-09/21-disable-co-author-in-claude-code.md
@@ -22,6 +22,6 @@ That's pretty much it.
 
 ## Reference
 - [Claude Code settings - Claude Docs](https://docs.claude.com/en/docs/claude-code/settings#available-settings)
-- https://x.com/screenfluent/status/1969649160237252819
+- [https://x.com/screenfluent/status/1969649160237252819](https://x.com/screenfluent/status/1969649160237252819)
 
 Happy clean commits!

--- a/content/blog/2025-09/24-openai-gpt-5-codex.md
+++ b/content/blog/2025-09/24-openai-gpt-5-codex.md
@@ -38,5 +38,5 @@ curl https://api.openai.com/v1/responses \
 ```
 
 ## References
-- https://openai.com/index/introducing-upgrades-to-codex/
-- https://platform.openai.com/docs/models/gpt-5-codex
+- [https://openai.com/index/introducing-upgrades-to-codex/](https://openai.com/index/introducing-upgrades-to-codex/)
+- [https://platform.openai.com/docs/models/gpt-5-codex](https://platform.openai.com/docs/models/gpt-5-codex)

--- a/content/blog/2025-09/25-claude-code-essentials-course-by-john-lindquist.md
+++ b/content/blog/2025-09/25-claude-code-essentials-course-by-john-lindquist.md
@@ -150,6 +150,6 @@ If you have such file make sure to give permission for it
 ```
 
 ## Credits
-- https://egghead.io/courses/claude-code-essentials~jc0n6 (obviously!)
+- [https://egghead.io/courses/claude-code-essentials~jc0n6](https://egghead.io/courses/claude-code-essentials~jc0n6) (obviously!)
 
 Happy learning-about claude!

--- a/content/blog/2025-09/26-github-copilot-cli.md
+++ b/content/blog/2025-09/26-github-copilot-cli.md
@@ -13,7 +13,7 @@ Another day, another agentic cli 😅
 
 GitHub Copilot has released their coding agent like Claude Code in public beta.
 
-👉 https://github.blog/changelog/2025-09-25-github-copilot-cli-is-now-in-public-preview/
+👉 [https://github.blog/changelog/2025-09-25-github-copilot-cli-is-now-in-public-preview/](https://github.blog/changelog/2025-09-25-github-copilot-cli-is-now-in-public-preview/)
 
 ![image.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/2025-09/eau8iwrxplngva8n8q69)
 

--- a/content/blog/2025-09/27-perplexity-search-api.md
+++ b/content/blog/2025-09/27-perplexity-search-api.md
@@ -121,6 +121,6 @@ You can pass the following param in the payload to get your desired output.
 | country             | string       | ISO 3166-1 alpha-2 country code to localize results          | `"US"`                                                                                                         |
 
 ## References
-- https://www.perplexity.ai/hub/blog/introducing-the-perplexity-search-api
-- https://x.com/perplexity_ai/status/1971274917401461236
+- [https://www.perplexity.ai/hub/blog/introducing-the-perplexity-search-api](https://www.perplexity.ai/hub/blog/introducing-the-perplexity-search-api)
+- [https://x.com/perplexity_ai/status/1971274917401461236](https://x.com/perplexity_ai/status/1971274917401461236)
 - [Search API Quick Start - Perplexity](https://docs.perplexity.ai/guides/search-quickstart)

--- a/content/blog/2025-09/29-anthropic-claude-sonnet-4-5.md
+++ b/content/blog/2025-09/29-anthropic-claude-sonnet-4-5.md
@@ -47,5 +47,5 @@ Here are some interesting tweets I read about Sonnet 4.5
 
 ## Reference
 - [Introducing Claude Sonnet 4.5 \ Anthropic](https://www.anthropic.com/news/claude-sonnet-4-5)
-- https://x.com/danshipper/status/1972708347141890258
+- [https://x.com/danshipper/status/1972708347141890258](https://x.com/danshipper/status/1972708347141890258)
 -

--- a/content/blog/2025-10/01-openai-sora-2.md
+++ b/content/blog/2025-10/01-openai-sora-2.md
@@ -27,6 +27,6 @@ To be honest, this feels like the what OpenAI GPT-4 did for the coding use case 
 
 ## Reference
 - [Sora 2 - Sam Altman](https://blog.samaltman.com/sora-2)
-- https://x.com/OpenAI/status/1973071069016641829
+- [https://x.com/OpenAI/status/1973071069016641829](https://x.com/OpenAI/status/1973071069016641829)
 
 Happy creating AI-videos!

--- a/content/blog/2025-10/03-droid-cli-system-prompt.md
+++ b/content/blog/2025-10/03-droid-cli-system-prompt.md
@@ -16,6 +16,6 @@ Not sure about how accurate that is but the prompt looks pretty insightful
 <script src="https://gist.github.com/AshikNesin/8c5b16f4f50734d1413bce4002223e22.js"></script>
 
 ## Credits
-- https://x.com/elder_plinius/status/1972429577608986908
+- [https://x.com/elder_plinius/status/1972429577608986908](https://x.com/elder_plinius/status/1972429577608986908)
 
 Happy learning prompts!

--- a/content/blog/2025-10/04-glm-4-6-in-droid-cli.md
+++ b/content/blog/2025-10/04-glm-4-6-in-droid-cli.md
@@ -42,9 +42,9 @@ Once you've added the config, you can now use the `/model` command in the `droid
 That's pretty much it.
 
 ## Credits
-- https://x.com/donvito/status/1974329346824585381/photo/1
+- [https://x.com/donvito/status/1974329346824585381/photo/1](https://x.com/donvito/status/1974329346824585381/photo/1)
 
 ## Reference
-- https://docs.factory.ai/cli/configuration/byok
+- [https://docs.factory.ai/cli/configuration/byok](https://docs.factory.ai/cli/configuration/byok)
 
 Happy AI-assisted coding!

--- a/content/blog/2025-10/05-postmark-mcp-malicious-email-backdoor.md
+++ b/content/blog/2025-10/05-postmark-mcp-malicious-email-backdoor.md
@@ -25,4 +25,4 @@ This is a good lesson that you should not be using a random MCP.
 And even for the official ones, it is recommended to use explicit versioning for anything that is mission critical.
 
 ## Reference
-- https://www.koi.ai/blog/postmark-mcp-npm-malicious-backdoor-email-theft
+- [https://www.koi.ai/blog/postmark-mcp-npm-malicious-backdoor-email-theft](https://www.koi.ai/blog/postmark-mcp-npm-malicious-backdoor-email-theft)

--- a/content/blog/2025-10/06-openai-bots-ip-address.md
+++ b/content/blog/2025-10/06-openai-bots-ip-address.md
@@ -23,4 +23,4 @@ They've 3 types of web crawlers/bot and each one performs specific tasks.
 You can use those IP address to validate those bots (and perform some action like allowing/dening)
 
 ## Reference
-https://platform.openai.com/docs/bots
+[https://platform.openai.com/docs/bots](https://platform.openai.com/docs/bots)

--- a/content/blog/2025-10/11-agentic-design-patterns-by-antonio-gulli.md
+++ b/content/blog/2025-10/11-agentic-design-patterns-by-antonio-gulli.md
@@ -15,7 +15,7 @@ It covers wide range of topics like these 👇
 
 ![2025-10-11-at-23.54.172x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/2025-10/mgaebr7ojjfb6lkwnocx)
 
-👉 https://docs.google.com/document/u/0/d/1rsaK53T3Lg5KoGwvf8ukOUvbELRtH-V0LnOIFDxBryE/mobilebasic?pli=1#ftnt_ref1
+👉 [https://docs.google.com/document/u/0/d/1rsaK53T3Lg5KoGwvf8ukOUvbELRtH-V0LnOIFDxBryE/mobilebasic?pli=1#ftnt_ref1](https://docs.google.com/document/u/0/d/1rsaK53T3Lg5KoGwvf8ukOUvbELRtH-V0LnOIFDxBryE/mobilebasic?pli=1#ftnt_ref1)
 
 I'm yet to read it. Once done, I'll update my feedback here in this post.
 

--- a/content/blog/2025-10/14-domain-filtering-in-perplexity-search-api.md
+++ b/content/blog/2025-10/14-domain-filtering-in-perplexity-search-api.md
@@ -55,7 +55,7 @@ Make sure to that you create a new API key else you'll be facing the following e
 ```
 
 ## Reference
-- https://x.com/PPLXDevs/status/1977778640566808620
-- https://docs.perplexity.ai/guides/search-quickstart#domain-filtering
+- [https://x.com/PPLXDevs/status/1977778640566808620](https://x.com/PPLXDevs/status/1977778640566808620)
+- [https://docs.perplexity.ai/guides/search-quickstart#domain-filtering](https://docs.perplexity.ai/guides/search-quickstart#domain-filtering)
 
 Happy instant searching!

--- a/content/blog/2025-10/15-nanochat-by-andrej-karpathy.md
+++ b/content/blog/2025-10/15-nanochat-by-andrej-karpathy.md
@@ -28,9 +28,9 @@ And much more.
 
 And the best part is, for **~$100** in cost (~4 hours on an 8XH100 node) you should be able to replicate it 🤯
 
-👉 https://github.com/karpathy/nanochat/discussions/1
+👉 [https://github.com/karpathy/nanochat/discussions/1](https://github.com/karpathy/nanochat/discussions/1)
 
 ## Reference
-https://x.com/karpathy/status/1977755427569111362
+[https://x.com/karpathy/status/1977755427569111362](https://x.com/karpathy/status/1977755427569111362)
 
 Happy building LLM!

--- a/content/blog/2025-10/16-anthropic-claude-haiku-4-5.md
+++ b/content/blog/2025-10/16-anthropic-claude-haiku-4-5.md
@@ -30,6 +30,6 @@ Sam Witteveen has a high level walk through of this model in his recent video ðŸ
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/lrf8eE-ADiw?si=Mehr2Hjl1KgJSyxj" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Reference
-- https://www.anthropic.com/news/claude-haiku-4-5
-- https://x.com/alexalbert__/status/1978506520355864813
-- https://docs.claude.com/en/docs/about-claude/models/overview#model-comparison-table
+- [https://www.anthropic.com/news/claude-haiku-4-5](https://www.anthropic.com/news/claude-haiku-4-5)
+- [https://x.com/alexalbert__/status/1978506520355864813](https://x.com/alexalbert__/status/1978506520355864813)
+- [https://docs.claude.com/en/docs/about-claude/models/overview#model-comparison-table](https://docs.claude.com/en/docs/about-claude/models/overview#model-comparison-table)

--- a/content/blog/2025-10/23-kilocode-cli.md
+++ b/content/blog/2025-10/23-kilocode-cli.md
@@ -30,4 +30,4 @@ Anyway, here is the official video by them.
 You can find the source code of this CLI 👉 https://github.com/Kilo-Org/kilocode/tree/main/cli which is a good learning material on how a agentic CLI is being built.
 
 ## Reference
-https://kilocode.ai/docs/cli
+[https://kilocode.ai/docs/cli](https://kilocode.ai/docs/cli)

--- a/content/blog/2025-10/31-huggingface-smol-training-playbook.md
+++ b/content/blog/2025-10/31-huggingface-smol-training-playbook.md
@@ -23,6 +23,6 @@ And this will be really useful reference if you plan on building an LLM from scr
 | Download PDF      | [PDF Download](https://huggingfacetb-smol-training-playbook.hf.space/the-smol-training-playbook-the-secrets-to-building-world-class-llms.pdf) |
 
 ## Reference
-- https://www.reddit.com/r/LocalLLaMA/comments/1ok3xie/200_pages_of_hugging_face_secrets_on_how_to_train/
+- [https://www.reddit.com/r/LocalLLaMA/comments/1ok3xie/200_pages_of_hugging_face_secrets_on_how_to_train/](https://www.reddit.com/r/LocalLLaMA/comments/1ok3xie/200_pages_of_hugging_face_secrets_on_how_to_train/)
 
 Happy learning about-LLM!

--- a/content/blog/2025-11/04-free-claude-code-web-credits-for-pro-max-users.md
+++ b/content/blog/2025-11/04-free-claude-code-web-credits-for-pro-max-users.md
@@ -23,8 +23,8 @@ Note: It is applicable for both new and old users as well.
 
 ![2025-11-04-at-22.51.162x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/2025-11/hdidj9kzmzbctsym7smx)
 
-👉 https://claude.ai/code
+👉 [https://claude.ai/code](https://claude.ai/code)
 
 ## Reference
-- https://support.claude.com/en/articles/12690958-claude-code-promotion
-- https://x.com/_catwu/status/1985754415161364700
+- [https://support.claude.com/en/articles/12690958-claude-code-promotion](https://support.claude.com/en/articles/12690958-claude-code-promotion)
+- [https://x.com/_catwu/status/1985754415161364700](https://x.com/_catwu/status/1985754415161364700)

--- a/content/blog/2025-11/06-github-copilot-inline-suggestion-open-source.md
+++ b/content/blog/2025-11/06-github-copilot-inline-suggestion-open-source.md
@@ -15,7 +15,7 @@ As promised earlier they've now open sourced **inline suggestions**
 
 ![image.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/2025-11/j3tgt0jrnmxrntankhao)
 
-👉 https://github.com/microsoft/vscode-copilot-chat/pull/1493
+👉 [https://github.com/microsoft/vscode-copilot-chat/pull/1493](https://github.com/microsoft/vscode-copilot-chat/pull/1493)
 
 ## What is inline suggestion?
 Basically, it's when you type something it'll suggest a contextually relavent suggestion in-line. That is the best use case for using AI in coding.

--- a/content/blog/2025-11/11-miniagent-open-source-coding-cli-agent.md
+++ b/content/blog/2025-11/11-miniagent-open-source-coding-cli-agent.md
@@ -17,7 +17,7 @@ Written in Python and MIT licensed
 Here is a quick peak of what you can learn from it 👇
 ![CleanShot-2025-11-11-at-23.36.482x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/2025-11/a5yipfifz9pmuyj0rfwo)
 
-👉 https://github.com/MiniMax-AI/Mini-Agent
+👉 [https://github.com/MiniMax-AI/Mini-Agent](https://github.com/MiniMax-AI/Mini-Agent)
 
 AICodeKing has a really good video about it which you might find interesting
 <iframe width="560" height="315" src="https://www.youtube.com/embed/FJrq3cvh6tU?si=MJ_5HCHREKDQmMoB&amp;start=391" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/content/blog/2025-11/12-virtual-hackathon-by-anthropic-gradio.md
+++ b/content/blog/2025-11/12-virtual-hackathon-by-anthropic-gradio.md
@@ -14,7 +14,7 @@ Anthropic & Gradio team is hosting a virtual hackathon on MCP theme from Nov 14-
 
 ![CleanShot-2025-11-12-at-23.14.40.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/2025-11/t5dd32tlbugdwpjjl5wp)
 
-👉 https://huggingface.co/MCP-1st-Birthday
+👉 [https://huggingface.co/MCP-1st-Birthday](https://huggingface.co/MCP-1st-Birthday)
 
 Apart from working an a cool project with team (or solo :P), you get free credits by different companies like OpenAI, ElevenLabs, etc
 

--- a/content/blog/2025-11/13-serve-markdown-to-ai-agents-accept-headers.md
+++ b/content/blog/2025-11/13-serve-markdown-to-ai-agents-accept-headers.md
@@ -40,7 +40,7 @@ And by sending `Accept: application/json, text/plain, */*` header, we're getting
 And Claude Code team claims that they'll start sending `Accept: “text/markdown"` then making a request in the upcoming versions.
 
 ## Reference
-- https://x.com/bcherny/status/1988860326306087102
-- https://x.com/bunjavascript/status/1971934734940098971
+- [https://x.com/bcherny/status/1988860326306087102](https://x.com/bcherny/status/1988860326306087102)
+- [https://x.com/bunjavascript/status/1971934734940098971](https://x.com/bunjavascript/status/1971934734940098971)
 
 Happy optimizing docs!

--- a/content/blog/2025-11/14-openai-gpt-5-1-apply-patch-tool.md
+++ b/content/blog/2025-11/14-openai-gpt-5-1-apply-patch-tool.md
@@ -51,6 +51,6 @@ Note: The `apply_patch` tool is only available through OpenAI's Responses API no
 You can refer the [guides](https://platform.openai.com/docs/guides/tools-apply-patch) on how to get use it in your codebase.
 
 ## Reference
-- https://openai.com/index/gpt-5-1-for-developers/
-- https://platform.openai.com/docs/guides/tools-apply-patch
-- https://github.com/cline/cline/blob/b002cdacdbd5d9f76928c37f65f83b4894f5b2a8/src/core/prompts/system-prompt/tools/replace_in_file.ts
+- [https://openai.com/index/gpt-5-1-for-developers/](https://openai.com/index/gpt-5-1-for-developers/)
+- [https://platform.openai.com/docs/guides/tools-apply-patch](https://platform.openai.com/docs/guides/tools-apply-patch)
+- [https://github.com/cline/cline/blob/b002cdacdbd5d9f76928c37f65f83b4894f5b2a8/src/core/prompts/system-prompt/tools/replace_in_file.ts](https://github.com/cline/cline/blob/b002cdacdbd5d9f76928c37f65f83b4894f5b2a8/src/core/prompts/system-prompt/tools/replace_in_file.ts)

--- a/content/blog/2025-11/15-anthropic-claude-structured-outputs.md
+++ b/content/blog/2025-11/15-anthropic-claude-structured-outputs.md
@@ -70,6 +70,6 @@ Response format: Valid JSON matching your schema in response.content[0].text
 ```
 
 ## Reference
-- https://docs.claude.com/en/docs/build-with-claude/structured-outputs
+- [https://docs.claude.com/en/docs/build-with-claude/structured-outputs](https://docs.claude.com/en/docs/build-with-claude/structured-outputs)
 
 Happy parsing content!

--- a/content/blog/2025-11/16-google-gemini-code-wiki.md
+++ b/content/blog/2025-11/16-google-gemini-code-wiki.md
@@ -27,4 +27,4 @@ As on now:
 👉 [Code Wiki](https://codewiki.google)
 
 ## Reference
-- https://developers.googleblog.com/en/introducing-code-wiki-accelerating-your-code-understanding/
+- [https://developers.googleblog.com/en/introducing-code-wiki-accelerating-your-code-understanding/](https://developers.googleblog.com/en/introducing-code-wiki-accelerating-your-code-understanding/)

--- a/content/blog/2025-11/17-google-prototype-to-production.md
+++ b/content/blog/2025-11/17-google-prototype-to-production.md
@@ -16,4 +16,4 @@ Google has published guide on how they take their AI apps from prototype to prod
 
 This guide looks pretty insightful. I'm yet to complete it, will read my notes in this blog post soon.
 
-👉 https://drive.google.com/file/d/1s00Cr_C8LXtrsGrlRG4WUJx4GmAtdzrQ/view
+👉 [https://drive.google.com/file/d/1s00Cr_C8LXtrsGrlRG4WUJx4GmAtdzrQ/view](https://drive.google.com/file/d/1s00Cr_C8LXtrsGrlRG4WUJx4GmAtdzrQ/view)

--- a/content/blog/2025-11/19-patterns-for-building-ai-agents-by-sam-bhagwat.md
+++ b/content/blog/2025-11/19-patterns-for-building-ai-agents-by-sam-bhagwat.md
@@ -11,6 +11,6 @@ qblog_id: 4646a87a-0832-4132-811e-07c85ddc658c
 
 Mastra team has relased their 2nd editon of **Patterns for Building AI Agents**
 
-👉 https://mastra.ai/book-2
+👉 [https://mastra.ai/book-2](https://mastra.ai/book-2)
 
 ![2025-11-19-at-23.54.142x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/2025-11/mxinaxmezkguv2xyekpv)

--- a/content/blog/2025-11/20-openai-gpt-5-1-codex-max.md
+++ b/content/blog/2025-11/20-openai-gpt-5-1-codex-max.md
@@ -19,4 +19,4 @@ From the benchmark that they've shared and whatever tweet that I've seen on Twit
 
 Right now it is available in Codex and it should be available in API soon.
 
-👉 https://openai.com/index/gpt-5-1-codex-max/
+👉 [https://openai.com/index/gpt-5-1-codex-max/](https://openai.com/index/gpt-5-1-codex-max/)

--- a/content/blog/2025-11/21-google-jules-repoless.md
+++ b/content/blog/2025-11/21-google-jules-repoless.md
@@ -16,6 +16,6 @@ Instead you can drag and drop your files/context and start building it.
 
 {{< video "https://video.twimg.com/amplify_video/1991571337173696512/vid/avc1/1280x720/UN87IACf5rBD3C1a.mp4" >}}
 
-https://x.com/julesagent/status/1991571865446543627
+[https://x.com/julesagent/status/1991571865446543627](https://x.com/julesagent/status/1991571865446543627)
 
 Happy building apps!

--- a/content/blog/2025-11/24-notes-on-agent-design-is-still-hard.md
+++ b/content/blog/2025-11/24-notes-on-agent-design-is-still-hard.md
@@ -46,4 +46,4 @@ Explict caching gives you opportunity to do context editing. And also it make it
 > Every time the agent runs a tool you have the opportunity to not just return data that the tool produces, but also to feed more information back into the loop. For instance, you can remind the agent about the overall objective and the status of individual tasks.
 
 ## Reference
-👉 https://lucumr.pocoo.org/2025/11/21/agents-are-hard/
+👉 [https://lucumr.pocoo.org/2025/11/21/agents-are-hard/](https://lucumr.pocoo.org/2025/11/21/agents-are-hard/)

--- a/content/blog/2025-11/26-anthropic-tool-search-tool.md
+++ b/content/blog/2025-11/26-anthropic-tool-search-tool.md
@@ -55,4 +55,4 @@ Similarly for MCP also you can define it.
 > The Claude Developer Platform provides regex-based and BM25-based search tools out of the box, but you can also implement custom search tools using embeddings or other strategies.
 
 ## Reference
-https://www.anthropic.com/engineering/advanced-tool-use
+[https://www.anthropic.com/engineering/advanced-tool-use](https://www.anthropic.com/engineering/advanced-tool-use)

--- a/content/blog/2025-11/29-huggingface-deepsite.md
+++ b/content/blog/2025-11/29-huggingface-deepsite.md
@@ -25,4 +25,4 @@ Here is a weather app that I've built using it.
 As you can [see](https://ashiknesin-weathervista-dashboard.static.hf.space/index.html) it has the AI vibe but it's a good start.
 
 ## Reference
-- https://x.com/victormustar/status/1994094025977016813
+- [https://x.com/victormustar/status/1994094025977016813](https://x.com/victormustar/status/1994094025977016813)

--- a/content/blog/2025-12/01-deepseek-v3-2.md
+++ b/content/blog/2025-12/01-deepseek-v3-2.md
@@ -19,4 +19,4 @@ It's not just open source for the sake of open source like how it is released by
 You can learn it here: https://huggingface.co/deepseek-ai/DeepSeek-V3.2/resolve/main/assets/paper.pdf
 
 ## Reference
-- https://xcancel.com/deepseek_ai/status/1995452646459858977#m
+- [https://xcancel.com/deepseek_ai/status/1995452646459858977#m](https://xcancel.com/deepseek_ai/status/1995452646459858977#m)

--- a/content/blog/2025-12/04-anthropic-claude-opus-4-5-thinking-free-on-google-antigravity.md
+++ b/content/blog/2025-12/04-anthropic-claude-opus-4-5-thinking-free-on-google-antigravity.md
@@ -18,4 +18,4 @@ Currently, Google's Antigravity is in public preview and it is free to use right
 👉 [Google Antigravity](https://antigravity.google/)
 
 ## Credits
-- https://x.com/marmaduke091/status/1996469717259731018
+- [https://x.com/marmaduke091/status/1996469717259731018](https://x.com/marmaduke091/status/1996469717259731018)

--- a/content/blog/2025-12/05-huggingface-llm-evaluation-guidebook-v2.md
+++ b/content/blog/2025-12/05-huggingface-llm-evaluation-guidebook-v2.md
@@ -17,6 +17,6 @@ And they cover basic concepts like how LLM works, tokenization, etc as well whic
 
 ![2025-12-05-at-21.20.092x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/2025-12/po8x1p01nwqxncvna07a)
 
-👉 https://openevals-evaluation-guidebook.hf.space/the-llm-evaluation-guidebook.pdf
+👉 [https://openevals-evaluation-guidebook.hf.space/the-llm-evaluation-guidebook.pdf](https://openevals-evaluation-guidebook.hf.space/the-llm-evaluation-guidebook.pdf)
 
 Happy benchmarking LLM!

--- a/content/blog/2025-12/07-state-of-ai-2025-by-openrouter.md
+++ b/content/blog/2025-12/07-state-of-ai-2025-by-openrouter.md
@@ -13,6 +13,6 @@ Open Router team has relased a detailed state of AI report based on the data tha
 
 ![CleanShot-2025-12-07-at-23.32.212x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/2025-12/einojdperysjkoigmlfz)
 
-👉 https://openrouter.ai/state-of-ai
+👉 [https://openrouter.ai/state-of-ai](https://openrouter.ai/state-of-ai)
 
 If you prefer pdf, https://openrouter.ai/assets/State-of-AI.pdf

--- a/content/blog/2025-12/08-advent-of-agents-by-google-cloud.md
+++ b/content/blog/2025-12/08-advent-of-agents-by-google-cloud.md
@@ -18,6 +18,6 @@ Here is an intro video by them 👇
 
 Overall, it looks good enough and you might find something interesting.
 
-👉 https://adventofagents.com
+👉 [https://adventofagents.com](https://adventofagents.com)
 
 Happy building agents!

--- a/content/blog/2025-12/11-advanced-rag-techniques-by-weaviate.md
+++ b/content/blog/2025-12/11-advanced-rag-techniques-by-weaviate.md
@@ -20,4 +20,4 @@ At a high level, they've covered:
 - Retrival
 - Post retrival like re-ranking and others
 
-👉 https://weaviate.io/ebooks/advanced-rag-techniques
+👉 [https://weaviate.io/ebooks/advanced-rag-techniques](https://weaviate.io/ebooks/advanced-rag-techniques)

--- a/content/blog/2025-12/12-openai-gpt-5-2.md
+++ b/content/blog/2025-12/12-openai-gpt-5-2.md
@@ -18,4 +18,4 @@ web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></if
 Overall, this model seems to be powerful than the old model 5.1 and it is little pricier than 5.1 as well.
 
 ## Referenc
-https://openai.com/index/introducing-gpt-5-2/
+[https://openai.com/index/introducing-gpt-5-2/](https://openai.com/index/introducing-gpt-5-2/)

--- a/content/blog/2025-12/13-show-context-window-information-in-claude-code-statusline.md
+++ b/content/blog/2025-12/13-show-context-window-information-in-claude-code-statusline.md
@@ -19,4 +19,4 @@ Add a progress bar showing the percentage of context currently used
 ![image.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/2025-12/vitoz3ha8oojo0c09ise)
 
 ## Reference
-https://x.com/claudeai/status/1999209597035331739
+[https://x.com/claudeai/status/1999209597035331739](https://x.com/claudeai/status/1999209597035331739)

--- a/content/blog/2025-12/14-stash-prompt-claude-code.md
+++ b/content/blog/2025-12/14-stash-prompt-claude-code.md
@@ -25,4 +25,4 @@ This tiny feature is a good user experience and it'll be helpful for us!
 Happy stashing prompts!
 
 ## Reference
-https://x.com/adocomplete/status/1999911937128509637
+[https://x.com/adocomplete/status/1999911937128509637](https://x.com/adocomplete/status/1999911937128509637)

--- a/content/blog/2025-12/15-word-of-the-year-2025-merriam-webster.md
+++ b/content/blog/2025-12/15-word-of-the-year-2025-merriam-webster.md
@@ -15,4 +15,4 @@ Merriam-Webster has chosed [**Slop**](https://www.merriam-webster.com/dictionary
 It's something that was created for the purpose of engagement without human effort (or very less effort). 
 
 ## Reference
-https://www.merriam-webster.com/wordplay/word-of-the-year
+[https://www.merriam-webster.com/wordplay/word-of-the-year](https://www.merriam-webster.com/wordplay/word-of-the-year)

--- a/content/blog/2025-12/17-openai-gpt-image-1-5.md
+++ b/content/blog/2025-12/17-openai-gpt-image-1-5.md
@@ -41,4 +41,4 @@ I tried it their default template and it did pretty good zero shot.
 ![2025-12-17-at-22.51.592x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/2025-12/lnuiw52mozuqaj4tbsag)
 
 ## Reference
-- https://platform.openai.com/docs/models/gpt-image-1.5
+- [https://platform.openai.com/docs/models/gpt-image-1.5](https://platform.openai.com/docs/models/gpt-image-1.5)

--- a/content/blog/2025-12/18-google-gemini-3-flash.md
+++ b/content/blog/2025-12/18-google-gemini-3-flash.md
@@ -19,4 +19,4 @@ It scores pretty good in benchmarks as well.
 It is available in [Gemini API](https://ai.google.dev/gemini-api/docs/models#gemini-3-flash) (Google AI Studio), Vertex AI, etc
 
 ## Reference
-https://blog.google/products/gemini/gemini-3-flash/
+[https://blog.google/products/gemini/gemini-3-flash/](https://blog.google/products/gemini/gemini-3-flash/)

--- a/content/blog/2025-12/21-2025-ai-engineer-reading-list-by-swyx.md
+++ b/content/blog/2025-12/21-2025-ai-engineer-reading-list-by-swyx.md
@@ -14,4 +14,4 @@ Swyx has curated the reading list (paper) if you're interested in AI Engineering
 
 ![2025-12-21-at-22.51.552x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/2025-12/fzphdsvtcvizejabedmy)
 
-👉 https://www.latent.space/p/2025-papers
+👉 [https://www.latent.space/p/2025-papers](https://www.latent.space/p/2025-papers)

--- a/content/blog/2025-12/22-z-ai-glm-4-7.md
+++ b/content/blog/2025-12/22-z-ai-glm-4-7.md
@@ -30,5 +30,5 @@ If you're on [GLM coding plan](https://go.nesin.io/glm), then you can access thi
 The model id is `glm-4.7`. Make sure to use that instead of old models.
 
 ## Reference
-https://z.ai/blog/glm-4.7
-https://docs.z.ai/guides/llm/glm-4.7
+[https://z.ai/blog/glm-4.7](https://z.ai/blog/glm-4.7)
+[https://docs.z.ai/guides/llm/glm-4.7](https://docs.z.ai/guides/llm/glm-4.7)

--- a/content/blog/2025-12/26-export-current-conversation-in-claude-code.md
+++ b/content/blog/2025-12/26-export-current-conversation-in-claude-code.md
@@ -15,4 +15,4 @@ This will give us option either to copy to `clipboard` or write it as a `markdow
 ![2025-12-26-at-20.05.27.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/2025-12/vdz1ti8xe5txxhl7lyuv)
 
 ## Reference
-https://x.com/adocomplete/status/2003870672418988170
+[https://x.com/adocomplete/status/2003870672418988170](https://x.com/adocomplete/status/2003870672418988170)

--- a/content/blog/2025-12/28-claude-code-started-as-side-project.md
+++ b/content/blog/2025-12/28-claude-code-started-as-side-project.md
@@ -18,4 +18,4 @@ It is interesting to know that Claude Code started as a **side project** by Bori
 ![2025-12-28-at-22.39.122x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/2025-12/zsqbvspa8n7y6kl9jzlv)
 
 ## Reference
-https://x.com/bcherny/status/2004887829252317325
+[https://x.com/bcherny/status/2004887829252317325](https://x.com/bcherny/status/2004887829252317325)

--- a/content/blog/2025-12/29-claude-code-z-ai-glm-4-7.md
+++ b/content/blog/2025-12/29-claude-code-z-ai-glm-4-7.md
@@ -12,7 +12,7 @@ Using the latest model GLM 4.7 from z.ai is straightforward
 
 Just get the API key from the dashboard
 
-https://z.ai/manage-apikey/apikey-list
+[https://z.ai/manage-apikey/apikey-list](https://z.ai/manage-apikey/apikey-list)
 
 Then you just need to set these things in the claude settings which is located at `~/.claude/settings.json`
 
@@ -38,4 +38,4 @@ You can also set these things so that the model names are configured properly as
   }
 ```
 ## Reference
-https://docs.z.ai/devpack/tool/claude
+[https://docs.z.ai/devpack/tool/claude](https://docs.z.ai/devpack/tool/claude)

--- a/content/blog/2025-12/30-lee-robinson-built-pixo-image-compressor.md
+++ b/content/blog/2025-12/30-lee-robinson-built-pixo-image-compressor.md
@@ -13,7 +13,7 @@ Lee Robinson has built a image compression app in Rust with zero depedency compl
 
 It runs on web (client side app) that runs entirely in the browser using WebAssembly.
 
-👉 https://leerob.com/pixo
+👉 [https://leerob.com/pixo](https://leerob.com/pixo)
 
 <blockquote class="twitter-tweet"><p lang="en" dir="ltr">I built a Rust-based image compressor, WASM binary, and SvelteKit app!<br><br>I wanted to see how far I could go using only coding agents.<br><br>I did not write any code by hand.<br><br>After 520 agents, 350M tokens, and $287 I can now say… extremely far.<a href="https://t.co/yxFL20j0PF">https://t.co/yxFL20j0PF</a> <a href="https://t.co/ftCzxvbXNE">pic.twitter.com/ftCzxvbXNE</a></p>&mdash; Lee Robinson (@leerob) <a href="https://twitter.com/leerob/status/2005700621463330888?ref_src=twsrc%5Etfw">December 29, 2025</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
@@ -25,7 +25,7 @@ So the goal for him is to see if AI can be used for low level apps like this whi
 
 You can play around with the app here:
 
-https://pixo.leerob.com
+[https://pixo.leerob.com](https://pixo.leerob.com)
 
 ## Reference
-https://leerob.com/pixo
+[https://leerob.com/pixo](https://leerob.com/pixo)

--- a/content/blog/2026-01/01-llms-in-2025.md
+++ b/content/blog/2026-01/01-llms-in-2025.md
@@ -13,4 +13,4 @@ qblog_id: f1825344-bdc4-4ecc-b43f-d06ec27ef523
 Simon Willison's has written annual roundup which you might find interesting to recap whatever happened in 2025 at high level.
 
 ## Reference
-https://simonwillison.net/2025/Dec/31/the-year-in-llms/
+[https://simonwillison.net/2025/Dec/31/the-year-in-llms/](https://simonwillison.net/2025/Dec/31/the-year-in-llms/)

--- a/content/blog/2026-01/02-doppler-cli-in-google-jules.md
+++ b/content/blog/2026-01/02-doppler-cli-in-google-jules.md
@@ -31,6 +31,6 @@ And also add the `DOPPLER_TOKEN` env in the settings as well.
 That's pretty much it. `doppler` cli will works as expected.
 
 ## Reference
-https://docs.doppler.com/docs/install-cli
+[https://docs.doppler.com/docs/install-cli](https://docs.doppler.com/docs/install-cli)
 
 Happy background coding!

--- a/content/blog/2026-01/03-improvise-spec-claude-code.md
+++ b/content/blog/2026-01/03-improvise-spec-claude-code.md
@@ -27,4 +27,4 @@ Here's a video by Prompt Engineering where uses this feature to build a text to 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/WHsRYkwR_YY?si=6uWFgHSECvcoCCxM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Reference
-https://x.com/trq212/status/2005315275026260309
+[https://x.com/trq212/status/2005315275026260309](https://x.com/trq212/status/2005315275026260309)

--- a/content/blog/2026-01/04-advent-of-claude-code-2025.md
+++ b/content/blog/2026-01/04-advent-of-claude-code-2025.md
@@ -15,4 +15,4 @@ Pretty useful stuffs. In fact, I've covered some of the claude code tips based o
 👉 [Advent of Claude: 31 Days of Claude Code — adocomplete](https://adocomplete.com/advent-of-claude-2025/)
 
 ## Reference
-https://x.com/adocomplete/status/2007518563356291573
+[https://x.com/adocomplete/status/2007518563356291573](https://x.com/adocomplete/status/2007518563356291573)

--- a/content/blog/2026-01/06-dynamically-load-mcp-in-claude-code.md
+++ b/content/blog/2026-01/06-dynamically-load-mcp-in-claude-code.md
@@ -24,6 +24,6 @@ And just use `claude` command.
 You can also check the token usage using `/context` command to see the token usage before and after as well.
 
 ## Reference
-https://github.com/anthropics/claude-code/issues/12836
+[https://github.com/anthropics/claude-code/issues/12836](https://github.com/anthropics/claude-code/issues/12836)
 
-https://x.com/sdrzn/status/2005660540576928074
+[https://x.com/sdrzn/status/2005660540576928074](https://x.com/sdrzn/status/2005660540576928074)

--- a/content/blog/2026-01/08-search-public-repo-repogrep.md
+++ b/content/blog/2026-01/08-search-public-repo-repogrep.md
@@ -23,4 +23,4 @@ With that context, it answers our questions.
 ![2026-01-08-at-23.02.472x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/2026-01/oes4l8qloh3scwqklbtp)
 
 ## Reference
-https://x.com/aidenybai/status/2008222085240549530
+[https://x.com/aidenybai/status/2008222085240549530](https://x.com/aidenybai/status/2008222085240549530)

--- a/content/blog/2026-01/09-multiple-system-prompts-with-anthropic-api.md
+++ b/content/blog/2026-01/09-multiple-system-prompts-with-anthropic-api.md
@@ -32,4 +32,4 @@ curl https://api.anthropic.com/v1/messages \
 Unlike OpenAI, Anthropic messages API does not have support for "system" role in input messages. We need to send them seperately under "system"
 
 ## Reference
-https://platform.claude.com/docs/en/api/messages/create
+[https://platform.claude.com/docs/en/api/messages/create](https://platform.claude.com/docs/en/api/messages/create)

--- a/content/blog/2026-01/10-anthropic-claude-opus-4-5-opencode-antigravity.md
+++ b/content/blog/2026-01/10-anthropic-claude-opus-4-5-opencode-antigravity.md
@@ -109,4 +109,4 @@ That's pretty much it, now you should be able to use those models in OpenCode.
 Just make sure you're on latest version of OpenCode if you face any issue.
 
 ## Reference
-https://github.com/NoeFabris/opencode-antigravity-auth
+[https://github.com/NoeFabris/opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth)

--- a/content/blog/2026-01/11-chatgpt-subscription-with-opencode.md
+++ b/content/blog/2026-01/11-chatgpt-subscription-with-opencode.md
@@ -25,4 +25,4 @@ Once it is successfully authenticated, you'll be able to use those models (`/mod
 ![2026-01-11-at-23.09.522x.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/2026-01/bnlutqeb9yiodspgaiis)
 
 ## Reference
-https://x.com/thdxr/status/2009803906461905202
+[https://x.com/thdxr/status/2009803906461905202](https://x.com/thdxr/status/2009803906461905202)

--- a/content/blog/2026-01/12-universal-commerce-protocol.md
+++ b/content/blog/2026-01/12-universal-commerce-protocol.md
@@ -21,4 +21,4 @@ Sam has a quick walkthrough about it which you might find useful to understand w
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/yDKpF6CjBUo?si=ulNGsSTjjTZ0fWnW" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Reference
-https://x.com/sundarpichai/status/2010382050570932299
+[https://x.com/sundarpichai/status/2010382050570932299](https://x.com/sundarpichai/status/2010382050570932299)

--- a/content/blog/2026-01/15-github-copilot-with-opencode.md
+++ b/content/blog/2026-01/15-github-copilot-with-opencode.md
@@ -30,4 +30,4 @@ Then authenticate it.
 Once you're done, you'll be able to choose the model using the `/model` command
 
 ## Reference
-https://x.com/jaredpalmer/status/2011803160122097826
+[https://x.com/jaredpalmer/status/2011803160122097826](https://x.com/jaredpalmer/status/2011803160122097826)

--- a/content/blog/2026-01/17-hide-org-email-in-claude-code.md
+++ b/content/blog/2026-01/17-hide-org-email-in-claude-code.md
@@ -15,4 +15,4 @@ However, if you set `export IS_DEMO=1` in the variable and then start then it'll
 ![image.png](https://images.nesin.io/f_auto,q_auto/qblog/AIEngineerGuide/2026-01/awqmaackzr9d6j2vn568)
 
 ## Reference
-https://x.com/shadcn/status/2012452027511513443
+[https://x.com/shadcn/status/2012452027511513443](https://x.com/shadcn/status/2012452027511513443)

--- a/content/blog/2026-01/18-ollama-claude-code.md
+++ b/content/blog/2026-01/18-ollama-claude-code.md
@@ -87,5 +87,5 @@ for block in message.content:
 ```
 
 ## Reference
-https://ollama.com/blog/claude
-https://x.com/ollama/status/2012434308091224534
+[https://ollama.com/blog/claude](https://ollama.com/blog/claude)
+[https://x.com/ollama/status/2012434308091224534](https://x.com/ollama/status/2012434308091224534)

--- a/content/blog/2026-01/19-cursor-agent-lifecycle-hooks.md
+++ b/content/blog/2026-01/19-cursor-agent-lifecycle-hooks.md
@@ -81,4 +81,4 @@ Something like this:
 ```
 
 ## Reference
-- https://cursor.com/docs/agent/hooks
+- [https://cursor.com/docs/agent/hooks](https://cursor.com/docs/agent/hooks)

--- a/content/blog/2026-01/20-cursor-ai-agents-better-code.md
+++ b/content/blog/2026-01/20-cursor-ai-agents-better-code.md
@@ -72,4 +72,4 @@ Here are some of the other tips by Cursor founder - Michael Truell which he has 
 - Run multiple agents/models in parallel via worktrees
 
 ## Reference
-- https://cursor.com/blog/agent-best-practices
+- [https://cursor.com/blog/agent-best-practices](https://cursor.com/blog/agent-best-practices)

--- a/content/blog/2026-01/21-improve-quality-claude-code-plan-mode.md
+++ b/content/blog/2026-01/21-improve-quality-claude-code-plan-mode.md
@@ -19,4 +19,4 @@ Just append this in your `~/.claude/CLAUDE.md`
 ```
 
 ## Reference
-https://www.aihero.dev/my-agents-md-file-for-building-plans-you-actually-read
+[https://www.aihero.dev/my-agents-md-file-for-building-plans-you-actually-read](https://www.aihero.dev/my-agents-md-file-for-building-plans-you-actually-read)

--- a/content/blog/2026-01/23-github-copilot-sdk.md
+++ b/content/blog/2026-01/23-github-copilot-sdk.md
@@ -84,5 +84,5 @@ Overall, I feel the way that Copilot SDK feels over-engineeried like having to r
 
 ## Reference
 
-- https://github.com/github/copilot-sdk/blob/main/docs/getting-started.md 
-- https://github.blog/news-insights/company-news/build-an-agent-into-any-app-with-the-github-copilot-sdk/
+- [https://github.com/github/copilot-sdk/blob/main/docs/getting-started.md](https://github.com/github/copilot-sdk/blob/main/docs/getting-started.md)
+- [https://github.blog/news-insights/company-news/build-an-agent-into-any-app-with-the-github-copilot-sdk/](https://github.blog/news-insights/company-news/build-an-agent-into-any-app-with-the-github-copilot-sdk/)

--- a/content/blog/2026-01/24-react-native-agent-skills-by-callstack.md
+++ b/content/blog/2026-01/24-react-native-agent-skills-by-callstack.md
@@ -12,7 +12,7 @@ qblog_id: 1f69d3c3-fddc-4d99-a543-c14f3f263c1f
 
 If you're someone who builds apps in react native it's good idea to use them.
 
-https://github.com/callstackincubator/agent-skills
+[https://github.com/callstackincubator/agent-skills](https://github.com/callstackincubator/agent-skills)
 
 ## How to get started?
 You can install the skills using add-skill cli packages

--- a/content/blog/2026-01/26-ollama-launch-command.md
+++ b/content/blog/2026-01/26-ollama-launch-command.md
@@ -40,4 +40,4 @@ ollama launch opencode --config
 ```
 
 ## Reference
-https://ollama.com/blog/launch
+[https://ollama.com/blog/launch](https://ollama.com/blog/launch)

--- a/content/blog/2026-01/27-google-antigravity-ide-models-with-clawdbot-moltbot.md
+++ b/content/blog/2026-01/27-google-antigravity-ide-models-with-clawdbot-moltbot.md
@@ -35,4 +35,4 @@ clawdbot gateway restart
 >Note: Depending on your alias, replace clawdbot with moltbot
 
 ## Reference
-https://docs.molt.bot/concepts/model-providers#google-vertex-/-antigravity-/-gemini-cli
+[https://docs.molt.bot/concepts/model-providers#google-vertex-/-antigravity-/-gemini-cli](https://docs.molt.bot/concepts/model-providers#google-vertex-/-antigravity-/-gemini-cli)

--- a/content/blog/2026-01/28-custom-keybindings-claude-code.md
+++ b/content/blog/2026-01/28-custom-keybindings-claude-code.md
@@ -15,5 +15,5 @@ You can configure it using the command `/keybindings`
 {{< video "https://video.twimg.com/amplify_video/2016221962582867968/vid/avc1/3840x1892/4UtrVTAJNclGTxP3.mp4" >}}
 
 ## Reference
-- https://x.com/bcherny/status/2016222113523483050
-- https://code.claude.com/docs/en/keybindings
+- [https://x.com/bcherny/status/2016222113523483050](https://x.com/bcherny/status/2016222113523483050)
+- [https://code.claude.com/docs/en/keybindings](https://code.claude.com/docs/en/keybindings)

--- a/content/blog/2026-01/29-custom-spinner-words-claude-code.md
+++ b/content/blog/2026-01/29-custom-spinner-words-claude-code.md
@@ -29,4 +29,4 @@ You can just add this in your claude settigs (`settings.json`
 ```
 
 ## Reference
-- https://xcancel.com/dani_avila7/status/2016700695357923717
+- [https://xcancel.com/dani_avila7/status/2016700695357923717](https://xcancel.com/dani_avila7/status/2016700695357923717)


### PR DESCRIPTION
Audited and fixed link formatting issues in `content/blog/` directory. Converted plain URLs and some inline code block URLs to Markdown links, while preserving code blocks and template strings.

---
*PR created automatically by Jules for task [12558329426773397860](https://jules.google.com/task/12558329426773397860) started by @AshikNesin*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized link formatting across blog posts by converting bare URLs to Markdown links. This improves readability and ensures links are clickable without altering code examples or templates.

- **Bug Fixes**
  - Converted plain and inline-code URLs to [url](url) where safe.
  - Skipped fenced code blocks and template strings (e.g., with %, { }).
  - Applied across content/blog/* for consistent, semantic linking.

<sup>Written for commit b15f77955ca54f4a12c7855ed36cb40ce0973649. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

