### PR TITLE
Improve link text with actual page titles for PR #7

### DIFF
--- a/content/blog/2025-01/01-llm-in-2024.md
+++ b/content/blog/2025-01/01-llm-in-2024.md
@@ -34,5 +34,5 @@ Here are some of the notable progress. It's primarily based on the summary writt
 	- Apps like Bolt.new, Vercel's v0, etc becoming more and more popular
 ## References
 - [Things we learned about LLMs in 2024](https://simonwillison.net/2024/Dec/31/llms-in-2024/)
-- https://huggingface.co/spaces/reach-vb/2024-ai-timeline
-- https://genai2024.replit.app/
+- [2024 AI Timeline](https://huggingface.co/spaces/reach-vb/2024-ai-timeline)
+- [AI in 2024 - Ben's Bites](https://genai2024.replit.app/)

--- a/content/blog/2025-01/28-open-source-alternatives-openai-operator.md
+++ b/content/blog/2025-01/28-open-source-alternatives-openai-operator.md
@@ -29,8 +29,8 @@ You can learn about how they're prompting and interacting with stagehand+Browser
 
 | **Resource** | **Link** |
 | --- | --- |
-| App | [https://operator.browserbase.com/](https://operator.browserbase.com/) |
-| Source Code | [https://github.com/browserbase/open-operator](https://github.com/browserbase/open-operator) |
+| App | [Open Operator](https://operator.browserbase.com/) |
+| Source Code | [browserbase/open-operator](https://github.com/browserbase/open-operator) |
 | License | stagehand - MIT, OpenOperator - MIT |
 Here is a quick demo of the app by [Paul Klein IV](https://x.com/pk_iv) (co-founder of Browserbase)
 


### PR DESCRIPTION
Fetched page titles for raw URL links and updated the link text in `content/blog/2025-01/01-llm-in-2024.md` and `content/blog/2025-01/28-open-source-alternatives-openai-operator.md`.
- `https://huggingface.co/spaces/reach-vb/2024-ai-timeline` -> `[2024 AI Timeline](...)`
- `https://genai2024.replit.app/` -> `[AI in 2024 - Ben's Bites](...)`
- `[https://operator.browserbase.com/](...)` -> `[Open Operator](...)`
- `[https://github.com/browserbase/open-operator](...)` -> `[browserbase/open-operator](...)`

---
*PR created automatically by Jules for task [14382877410675002925](https://jules.google.com/task/14382877410675002925) started by @AshikNesin*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced raw URL link text with the actual page titles to improve readability and accessibility. Updated links in content/blog/2025-01/01-llm-in-2024.md and content/blog/2025-01/28-open-source-alternatives-openai-operator.md.

<sup>Written for commit cc97133f375c17e5239d4e144a8d37980a6e2065. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

