### PR TITLE
Add redirect for Claude Opus 4.5 blog post

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,2 +1,3 @@
 /blog/26-openai-operator-prompt /blog/openai-operator-prompt 301 
 /blog/llm-interview-questions/ /blog/llm-interview-questions-by-hao-hoang/ 301
+/blog/anthropic-claude-opus-4.5-opencode-antigravity /blog/2026-01/10-anthropic-claude-opus-4-5-opencode-antigravity/ 301


### PR DESCRIPTION
Added a 301 redirect in `static/_redirects` to map `/blog/anthropic-claude-opus-4.5-opencode-antigravity` to `/blog/2026-01/10-anthropic-claude-opus-4-5-opencode-antigravity/`. This fixes a URL issue where the dot was used instead of a hyphen.

---
*PR created automatically by Jules for task [7805058259701957469](https://jules.google.com/task/7805058259701957469) started by @AshikNesin*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 301 redirect from /blog/anthropic-claude-opus-4.5-opencode-antigravity to /blog/2026-01/10-anthropic-claude-opus-4-5-opencode-antigravity/. Fixes the dot vs hyphen slug so old links resolve and SEO is preserved.

<sup>Written for commit 66a92b25c27c1a62b7dd3d16ed033d2726dbb455. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

