### PR TITLE
fix search result layout

### DIFF
--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -433,7 +433,7 @@
                                 item.url ||
                                 `${window.location.origin}/${item.slug}`;
                             html +=
-                                '<a href="' +
+                                '<div data-url="' +
                                 escapeHtml(url) +
                                 '" class="search-result-item" tabindex="0">' +
                                 '<div class="search-result-title">' +
@@ -443,7 +443,7 @@
                                 escapeHtml(excerpt) +
                                 "</div>" +
                                 tags +
-                                "</a>";
+                                "</div>";
                         });
                         results.innerHTML = html;
                     })
@@ -457,15 +457,19 @@
         });
 
         results.addEventListener("click", function (e) {
-            var link = e.target.closest(".search-result-item");
-            if (link) closeModal();
+            if (e.target.closest(".search-result-tag")) return;
+            var item = e.target.closest(".search-result-item");
+            if (item) {
+                closeModal();
+                window.location.href = item.dataset.url;
+            }
         });
 
         results.addEventListener("keydown", function (e) {
             if (e.key === "Enter") {
-                var link = e.target.closest(".search-result-item");
-                if (link) {
-                    window.location.href = link.href;
+                var item = e.target.closest(".search-result-item");
+                if (item) {
+                    window.location.href = item.dataset.url;
                 }
             }
         });

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -427,7 +427,7 @@
                                             return (
                                                 '<a href="https://aiengineerguide.com/tags/' +
                                                 encodeURIComponent(t) +
-                                                '" class="search-result-tag" target="_blank" rel="noopener noreferrer">' +
+                                                '" class="search-result-tag" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()">' +
                                                 escapeHtml(t) +
                                                 "</a>"
                                             );
@@ -439,7 +439,7 @@
                                 item.url ||
                                 `${window.location.origin}/${item.slug}`;
                             html +=
-                                '<div data-url="' +
+                                '<a href="' +
                                 escapeHtml(url) +
                                 '" class="search-result-item" tabindex="0">' +
                                 '<div class="search-result-title">' +
@@ -449,7 +449,7 @@
                                 escapeHtml(excerpt) +
                                 "</div>" +
                                 tags +
-                                "</div>";
+                                "</a>";
                         });
                         results.innerHTML = html;
                     })
@@ -463,21 +463,7 @@
         });
 
         results.addEventListener("click", function (e) {
-            if (e.target.closest(".search-result-tag")) return;
-            var item = e.target.closest(".search-result-item");
-            if (item) {
-                closeModal();
-                window.location.href = item.dataset.url;
-            }
-        });
-
-        results.addEventListener("keydown", function (e) {
-            if (e.key === "Enter") {
-                var item = e.target.closest(".search-result-item");
-                if (item) {
-                    window.location.href = item.dataset.url;
-                }
-            }
+            if (e.target.closest(".search-result-item")) closeModal();
         });
 
         function escapeHtml(str) {

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -177,9 +177,11 @@
         border-radius: 3px;
         white-space: nowrap;
         text-decoration: none;
+        transition: background 0.15s, color 0.15s;
     }
     .search-result-tag:hover {
-        background: #e0e0e0;
+        background: rgba(50, 115, 220, 0.1);
+        color: #3273dc;
     }
 
     .search-modal-message {
@@ -229,6 +231,10 @@
             background: #444;
             color: #aaa;
             text-decoration: none;
+        }
+        .search-result-tag:hover {
+            background: rgba(140, 194, 221, 0.15);
+            color: #8cc2dd;
         }
         .search-modal-message {
             color: #aaa;

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -421,7 +421,7 @@
                                             return (
                                                 '<a href="https://aiengineerguide.com/tags/' +
                                                 encodeURIComponent(t) +
-                                                '" class="search-result-tag" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()">' +
+                                                '" class="search-result-tag" target="_blank" rel="noopener noreferrer">' +
                                                 escapeHtml(t) +
                                                 "</a>"
                                             );


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restores native link behavior in search results and polishes tag hover styles with theme-aware colors. Removes custom JS navigation while keeping the modal closing on item click.

- **Bug Fixes**
  - Restored outer result `<a href>` to bring back native behaviors (middle‑click, Ctrl/Cmd+click, screen readers).
  - Removed custom Enter key handler; browser now handles keyboard navigation (Enter on a tag follows the tag).
  - Stopped propagation on tag clicks so tags navigate without triggering the parent link; close the modal on item click before navigating.

<sup>Written for commit 768552587f5fa1a347a722218126b3a8574dd1dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

