### PR TITLE
Update search result item styles and link behavior

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -12,11 +12,37 @@
 <content>
   {{ .Content }}
 </content>
-<p>
+<div class="post-tags">
   {{ range (.GetTerms "tags") }}
-  <a href="{{ .Permalink }}">#{{ .LinkTitle }}</a>
+  <a href="{{ .Permalink }}" class="post-tag">#{{ .LinkTitle }}</a>
   {{ end }}
-</p>
+</div>
+
+<style>
+.post-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 1.5rem;
+}
+.post-tag {
+  font-size: 13px;
+  background: #f0f0f0;
+  color: #666;
+  padding: 3px 8px;
+  border-radius: 4px;
+  text-decoration: none;
+  transition: background 0.15s, color 0.15s;
+}
+.post-tag:hover {
+  background: rgba(50, 115, 220, 0.1);
+  color: #3273dc;
+}
+@media (prefers-color-scheme: dark) {
+  .post-tag { background: #444; color: #aaa; }
+  .post-tag:hover { background: rgba(140, 194, 221, 0.15); color: #8cc2dd; }
+}
+</style>
 
 {{ if eq .Type "blog" }}
   {{ partial "sidebar.html" . }}

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -132,19 +132,24 @@
 
     .search-result-item {
         display: block;
-        padding: 12px 16px;
         border-bottom: 1px solid #f0f0f0;
-        cursor: pointer;
-        text-decoration: none;
-        color: inherit;
     }
-    .search-result-item:hover,
-    .search-result-item:focus {
+    .search-result-item:hover {
         background: #f7f7f7;
-        outline: none;
     }
     .search-result-item:last-child {
         border-bottom: none;
+    }
+
+    .search-result-link {
+        display: block;
+        padding: 12px 16px 4px;
+        text-decoration: none;
+        color: inherit;
+        cursor: pointer;
+    }
+    .search-result-link:focus {
+        outline: none;
     }
 
     .search-result-title {
@@ -163,7 +168,8 @@
         overflow: hidden;
     }
     .search-result-tags {
-        margin-top: 4px;
+        margin-top: 0;
+        padding: 0 16px 12px;
         display: flex;
         gap: 4px;
         flex-wrap: nowrap;
@@ -427,7 +433,7 @@
                                             return (
                                                 '<a href="https://aiengineerguide.com/tags/' +
                                                 encodeURIComponent(t) +
-                                                '" class="search-result-tag" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()">' +
+                                                '" class="search-result-tag" target="_blank" rel="noopener noreferrer">' +
                                                 escapeHtml(t) +
                                                 "</a>"
                                             );
@@ -439,17 +445,19 @@
                                 item.url ||
                                 `${window.location.origin}/${item.slug}`;
                             html +=
+                                '<div class="search-result-item">' +
                                 '<a href="' +
                                 escapeHtml(url) +
-                                '" class="search-result-item" tabindex="0">' +
+                                '" class="search-result-link" tabindex="0">' +
                                 '<div class="search-result-title">' +
                                 escapeHtml(item.title || "") +
                                 "</div>" +
                                 '<div class="search-result-excerpt">' +
                                 escapeHtml(excerpt) +
                                 "</div>" +
+                                "</a>" +
                                 tags +
-                                "</a>";
+                                "</div>";
                         });
                         results.innerHTML = html;
                     })
@@ -463,7 +471,7 @@
         });
 
         results.addEventListener("click", function (e) {
-            if (e.target.closest(".search-result-item")) closeModal();
+            if (e.target.closest(".search-result-link")) closeModal();
         });
 
         function escapeHtml(str) {

--- a/layouts/til/single.html
+++ b/layouts/til/single.html
@@ -22,11 +22,11 @@
   {{ .Content }}
 </content>
 
-<p class="til-tags">
+<div class="til-tags">
   {{ range (.GetTerms "tags") }}
-  <a href="{{ .Permalink }}">#{{ .LinkTitle }}</a>
+  <a href="{{ .Permalink }}" class="post-tag">#{{ .LinkTitle }}</a>
   {{ end }}
-</p>
+</div>
 
 {{ partial "sidebar.html" . }}
 {{ partial "comments.html" . }}
@@ -90,8 +90,26 @@
   text-decoration: underline;
 }
 
-.til-tags a {
-  margin-right: 0.5rem;
+.til-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 1.5rem;
+}
+
+.post-tag {
+  font-size: 13px;
+  background: #f0f0f0;
+  color: #666;
+  padding: 3px 8px;
+  border-radius: 4px;
+  text-decoration: none;
+  transition: background 0.15s, color 0.15s;
+}
+
+.post-tag:hover {
+  background: rgba(50, 115, 220, 0.1);
+  color: #3273dc;
 }
 
 /* Dark mode */
@@ -113,6 +131,16 @@
   }
   
   .til-author-name {
+    color: #8cc2dd;
+  }
+  
+  .post-tag {
+    background: #444;
+    color: #aaa;
+  }
+  
+  .post-tag:hover {
+    background: rgba(140, 194, 221, 0.15);
     color: #8cc2dd;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated search results so only the title/excerpt is clickable; tags are separate and open in a new tab. Added chip‑style tags on blog and TIL pages with dark‑mode styles; tightened spacing and hovers.

- **Bug Fixes**
  - Restructured markup to avoid nested anchors: wrapped title/excerpt in `a.search-result-link` inside `div.search-result-item`; moved padding to the link and kept hover on the container for consistent styling.
  - Updated click handling: removed inline `event.stopPropagation()` and now close the modal only when `.search-result-link` is clicked; clicking tags no longer closes the modal.

<sup>Written for commit c04a01592bed8eea5b0b019d59ffd5eafa0de8fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

