### PR TITLE
Feat/related posts

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -44,6 +44,8 @@
 }
 </style>
 
+{{ partial "related-posts.html" . }}
+
 {{ if eq .Type "blog" }}
   {{ partial "sidebar.html" . }}
   <!-- {{ partial "content-feedback.html" . }} -->

--- a/layouts/partials/related-posts.html
+++ b/layouts/partials/related-posts.html
@@ -135,7 +135,13 @@
   function sanitizeUrl(url) {
     if (!url) return "";
     var tempUrl = url.trim();
-    if (tempUrl.toLowerCase().indexOf("javascript:") === 0) return "#";
+    var match = tempUrl.match(/^[a-zA-Z][a-zA-Z0-9+.-]*:/);
+    if (match) {
+      var proto = match[0].toLowerCase();
+      if (proto !== "http:" && proto !== "https:" && proto !== "mailto:" && proto !== "tel:") {
+        return "#";
+      }
+    }
     return tempUrl;
   }
 

--- a/layouts/partials/related-posts.html
+++ b/layouts/partials/related-posts.html
@@ -140,7 +140,7 @@
           var visibleTags = item.tags.slice(0, 3);
           tags = '<div class="related-post-tags">' +
             visibleTags.map(function (t) {
-              return '<span class="post-tag">' + escapeHtml(t) + '</span>';
+              return '<a href="https://aiengineerguide.com/tags/' + encodeURIComponent(t) + '" class="post-tag" target="_blank" rel="noopener noreferrer">' + escapeHtml(t) + '</a>';
             }).join("") +
             '</div>';
         }

--- a/layouts/partials/related-posts.html
+++ b/layouts/partials/related-posts.html
@@ -1,0 +1,168 @@
+<div id="related-posts" class="related-posts">
+  <h3 class="related-posts-heading">Related Posts</h3>
+  <div class="related-posts-spinner" id="related-posts-spinner"></div>
+  <div id="related-posts-results"></div>
+</div>
+
+<style>
+.related-posts {
+  margin-top: 2.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid #e8e8e8;
+}
+.related-posts.hidden { display: none; }
+
+.related-posts-heading {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #222;
+  margin: 0 0 1.25rem 0;
+}
+
+.related-posts-spinner {
+  display: flex;
+  justify-content: center;
+  padding: 2rem 0;
+}
+.related-posts-spinner.hidden { display: none; }
+.related-posts-spinner::after {
+  content: "";
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+  border: 2px solid #e8e8e8;
+  border-top-color: #3273dc;
+  border-radius: 50%;
+  animation: related-spin 0.6s linear infinite;
+}
+@keyframes related-spin { to { transform: rotate(360deg); } }
+
+.related-post-card {
+  display: block;
+  padding: 1rem 1.125rem;
+  border: 1px solid #e8e8e8;
+  border-radius: 8px;
+  margin-bottom: 0.75rem;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.related-post-card:hover {
+  border-color: #3273dc;
+  box-shadow: 0 2px 8px rgba(50, 115, 220, 0.08);
+}
+
+.related-post-title {
+  font-weight: 600;
+  color: #222;
+  font-size: 0.95rem;
+  margin-bottom: 0.25rem;
+}
+
+.related-post-meta {
+  font-size: 0.8125rem;
+  color: #777;
+  margin-bottom: 0.5rem;
+}
+
+.related-post-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .related-posts { border-top-color: #444; }
+  .related-posts-heading { color: #eee; }
+  .related-posts-spinner::after {
+    border-color: #444;
+    border-top-color: #8cc2dd;
+  }
+  .related-post-card {
+    border-color: #444;
+  }
+  .related-post-card:hover {
+    border-color: #8cc2dd;
+    box-shadow: 0 2px 8px rgba(140, 194, 221, 0.08);
+  }
+  .related-post-title { color: #eee; }
+  .related-post-meta { color: #aaa; }
+}
+</style>
+
+<script>
+(function () {
+  var container = document.getElementById("related-posts");
+  var spinner = document.getElementById("related-posts-spinner");
+  var results = document.getElementById("related-posts-results");
+
+  if (!container || !spinner || !results) return;
+
+  function escapeHtml(str) {
+    var div = document.createElement("div");
+    div.appendChild(document.createTextNode(str));
+    return div.innerHTML;
+  }
+
+  function formatDate(dateStr) {
+    try {
+      var d = new Date(dateStr);
+      var months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+      return months[d.getMonth()] + " " + d.getDate() + ", " + d.getFullYear();
+    } catch (e) {
+      return "";
+    }
+  }
+
+  var currentUrl = window.location.href;
+  var apiUrl = "/api/related?limit=5&url=" + encodeURIComponent(currentUrl);
+  var controller = new AbortController();
+
+  fetch(apiUrl, { signal: controller.signal })
+    .then(function (res) {
+      if (!res.ok) throw new Error("HTTP " + res.status);
+      return res.json();
+    })
+    .then(function (data) {
+      spinner.classList.add("hidden");
+
+      if (!data.success || !data.data || !data.data.items || data.data.items.length === 0) {
+        container.classList.add("hidden");
+        return;
+      }
+
+      var html = "";
+      data.data.items.forEach(function (item) {
+        var date = item.publishedAt ? formatDate(item.publishedAt) : "";
+        var tags = "";
+
+        if (item.tags && item.tags.length > 0) {
+          var visibleTags = item.tags.slice(0, 3);
+          tags = '<div class="related-post-tags">' +
+            visibleTags.map(function (t) {
+              return '<span class="post-tag">' + escapeHtml(t) + '</span>';
+            }).join("") +
+            '</div>';
+        }
+
+        var url = item.url || (window.location.origin + "/" + item.slug);
+
+        html += '<a href="' + escapeHtml(url) + '" class="related-post-card">' +
+          '<div class="related-post-title">' + escapeHtml(item.title || "") + '</div>' +
+          (date ? '<div class="related-post-meta">' + escapeHtml(date) + '</div>' : '') +
+          tags +
+          '</a>';
+      });
+
+      results.innerHTML = html;
+    })
+    .catch(function (err) {
+      if (err.name === "AbortError") return;
+      container.classList.add("hidden");
+    });
+
+  window.addEventListener("beforeunload", function () {
+    controller.abort();
+  });
+})();
+</script>

--- a/layouts/partials/related-posts.html
+++ b/layouts/partials/related-posts.html
@@ -39,17 +39,22 @@
 
 .related-post-card {
   display: block;
-  padding: 1rem 1.125rem;
   border: 1px solid #e8e8e8;
   border-radius: 8px;
   margin-bottom: 0.75rem;
-  text-decoration: none;
-  color: inherit;
   transition: border-color 0.15s, box-shadow 0.15s;
 }
 .related-post-card:hover {
   border-color: #3273dc;
   box-shadow: 0 2px 8px rgba(50, 115, 220, 0.08);
+}
+
+.related-post-link {
+  display: block;
+  padding: 1rem 1.125rem 0.5rem;
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
 }
 
 .related-post-title {
@@ -62,13 +67,14 @@
 .related-post-meta {
   font-size: 0.8125rem;
   color: #777;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.125rem;
 }
 
 .related-post-tags {
   display: flex;
   gap: 4px;
   flex-wrap: wrap;
+  padding: 0 1.125rem 1rem;
 }
 
 .related-post-tag {
@@ -170,11 +176,13 @@
         var url = item.url || (window.location.origin + "/" + item.slug);
         url += (url.indexOf("?") === -1 ? "?" : "&") + "ref=related_posts";
 
-        html += '<a href="' + escapeHtml(url) + '" class="related-post-card">' +
+        html += '<div class="related-post-card">' +
+          '<a href="' + escapeHtml(url) + '" class="related-post-link">' +
           '<div class="related-post-title">' + escapeHtml(item.title || "") + '</div>' +
           (date ? '<div class="related-post-meta">' + escapeHtml(date) + '</div>' : '') +
+          '</a>' +
           tags +
-          '</a>';
+          '</div>';
       });
 
       results.innerHTML = html;

--- a/layouts/partials/related-posts.html
+++ b/layouts/partials/related-posts.html
@@ -65,10 +65,29 @@
   margin-bottom: 0.5rem;
 }
 
-.related-post-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
+.related-post-tag {
+  font-size: 12px;
+  background: #f0f0f0;
+  color: #666;
+  padding: 2px 7px;
+  border-radius: 3px;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: background 0.15s, color 0.15s;
+}
+.related-post-tag:hover {
+  background: rgba(50, 115, 220, 0.1);
+  color: #3273dc;
+}
+@media (prefers-color-scheme: dark) {
+  .related-post-tag {
+    background: #444;
+    color: #aaa;
+  }
+  .related-post-tag:hover {
+    background: rgba(140, 194, 221, 0.15);
+    color: #8cc2dd;
+  }
 }
 
 @media (prefers-color-scheme: dark) {
@@ -140,7 +159,7 @@
           var visibleTags = item.tags.slice(0, 3);
           tags = '<div class="related-post-tags">' +
             visibleTags.map(function (t) {
-              return '<a href="https://aiengineerguide.com/tags/' + encodeURIComponent(t) + '" class="post-tag" target="_blank" rel="noopener noreferrer">' + escapeHtml(t) + '</a>';
+              return '<a href="https://aiengineerguide.com/tags/' + encodeURIComponent(t) + '" class="related-post-tag" target="_blank" rel="noopener noreferrer">' + escapeHtml(t) + '</a>';
             }).join("") +
             '</div>';
         }

--- a/layouts/partials/related-posts.html
+++ b/layouts/partials/related-posts.html
@@ -174,10 +174,9 @@
         }
 
         var url = item.url || (window.location.origin + "/" + item.slug);
-        url += (url.indexOf("?") === -1 ? "?" : "&") + "ref=related_posts";
 
         html += '<div class="related-post-card">' +
-          '<a href="' + escapeHtml(url) + '" class="related-post-link">' +
+          '<a href="' + escapeHtml(url) + '" class="related-post-link" data-umami-event="related-post-click" data-umami-event-title="' + escapeHtml(item.title || "") + '">' +
           '<div class="related-post-title">' + escapeHtml(item.title || "") + '</div>' +
           (date ? '<div class="related-post-meta">' + escapeHtml(date) + '</div>' : '') +
           '</a>' +

--- a/layouts/partials/related-posts.html
+++ b/layouts/partials/related-posts.html
@@ -132,9 +132,17 @@
     return div.innerHTML;
   }
 
+  function sanitizeUrl(url) {
+    if (!url) return "";
+    var tempUrl = url.trim();
+    if (tempUrl.toLowerCase().indexOf("javascript:") === 0) return "#";
+    return tempUrl;
+  }
+
   function formatDate(dateStr) {
     try {
       var d = new Date(dateStr);
+      if (isNaN(d.getTime())) return "";
       var months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
       return months[d.getMonth()] + " " + d.getDate() + ", " + d.getFullYear();
     } catch (e) {
@@ -174,6 +182,7 @@
         }
 
         var url = item.url || (window.location.origin + "/" + item.slug);
+        url = sanitizeUrl(url);
 
         html += '<div class="related-post-card">' +
           '<a href="' + escapeHtml(url) + '" class="related-post-link" data-umami-event="related-post-click" data-umami-event-title="' + escapeHtml(item.title || "") + '">' +

--- a/layouts/partials/related-posts.html
+++ b/layouts/partials/related-posts.html
@@ -146,6 +146,7 @@
         }
 
         var url = item.url || (window.location.origin + "/" + item.slug);
+        url += (url.indexOf("?") === -1 ? "?" : "&") + "ref=related_posts";
 
         html += '<a href="' + escapeHtml(url) + '" class="related-post-card">' +
           '<div class="related-post-title">' + escapeHtml(item.title || "") + '</div>' +

--- a/layouts/partials/related-posts.html
+++ b/layouts/partials/related-posts.html
@@ -65,29 +65,24 @@
   margin-bottom: 0.5rem;
 }
 
+.related-post-tags {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
 .related-post-tag {
-  font-size: 12px;
+  font-size: 11px;
   background: #f0f0f0;
   color: #666;
-  padding: 2px 7px;
+  padding: 1px 6px;
   border-radius: 3px;
-  text-decoration: none;
   white-space: nowrap;
-  transition: background 0.15s, color 0.15s;
+  text-decoration: none;
 }
 .related-post-tag:hover {
   background: rgba(50, 115, 220, 0.1);
   color: #3273dc;
-}
-@media (prefers-color-scheme: dark) {
-  .related-post-tag {
-    background: #444;
-    color: #aaa;
-  }
-  .related-post-tag:hover {
-    background: rgba(140, 194, 221, 0.15);
-    color: #8cc2dd;
-  }
 }
 
 @media (prefers-color-scheme: dark) {
@@ -106,6 +101,14 @@
   }
   .related-post-title { color: #eee; }
   .related-post-meta { color: #aaa; }
+  .related-post-tag {
+    background: #444;
+    color: #aaa;
+  }
+  .related-post-tag:hover {
+    background: rgba(140, 194, 221, 0.15);
+    color: #8cc2dd;
+  }
 }
 </style>
 

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -502,7 +502,13 @@
         function sanitizeUrl(url) {
             if (!url) return "";
             var tempUrl = url.trim();
-            if (tempUrl.toLowerCase().indexOf("javascript:") === 0) return "#";
+            var match = tempUrl.match(/^[a-zA-Z][a-zA-Z0-9+.-]*:/);
+            if (match) {
+                var proto = match[0].toLowerCase();
+                if (proto !== "http:" && proto !== "https:" && proto !== "mailto:" && proto !== "tel:") {
+                    return "#";
+                }
+            }
             return tempUrl;
         }
     })();

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -441,9 +441,8 @@
                                         .join("") +
                                     "</div>";
                             }
-                            const url =
-                                item.url ||
-                                `${window.location.origin}/${item.slug}`;
+                            const baseUrl = item.url || `${window.location.origin}/${item.slug}`;
+                            const url = baseUrl + (baseUrl.indexOf("?") === -1 ? "?" : "&") + "ref=search";
                             html +=
                                 '<div class="search-result-item">' +
                                 '<a href="' +

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -461,7 +461,8 @@
                                         .join("") +
                                     "</div>";
                             }
-                            const url = item.url || `${window.location.origin}/${item.slug}`;
+                            let url = item.url || `${window.location.origin}/${item.slug}`;
+                            url = sanitizeUrl(url);
                             html +=
                                 '<div class="search-result-item">' +
                                 '<a href="' +
@@ -496,6 +497,13 @@
             var div = document.createElement("div");
             div.appendChild(document.createTextNode(str));
             return div.innerHTML;
+        }
+
+        function sanitizeUrl(url) {
+            if (!url) return "";
+            var tempUrl = url.trim();
+            if (tempUrl.toLowerCase().indexOf("javascript:") === 0) return "#";
+            return tempUrl;
         }
     })();
 </script>

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -130,15 +130,30 @@
         }
     }
 
+    #search-results {
+        max-height: 60vh;
+        overflow-y: auto;
+    }
+    #search-results:not(:empty) {
+        padding: 16px;
+    }
+
     .search-result-item {
         display: block;
-        border-bottom: 1px solid #f0f0f0;
+        border: 1px solid #e8e8e8;
+        border-radius: 8px;
+        margin-bottom: 0.75rem;
+        transition:
+            border-color 0.15s,
+            box-shadow 0.15s;
     }
     .search-result-item:hover {
-        background: #f7f7f7;
+        border-color: #3273dc;
+        box-shadow: 0 2px 8px rgba(50, 115, 220, 0.08);
+        background: transparent;
     }
     .search-result-item:last-child {
-        border-bottom: none;
+        margin-bottom: 0;
     }
 
     .search-result-link {
@@ -191,7 +206,7 @@
     }
 
     .search-modal-message {
-        padding: 20px 16px;
+        padding: 4px 0;
         text-align: center;
         color: #888;
         font-size: 14px;
@@ -223,9 +238,14 @@
             color: #ddd;
             border-bottom-color: #444;
         }
+        .search-result-item {
+            border-color: #444;
+        }
         .search-result-item:hover,
         .search-result-item:focus {
-            background: #3a3a3a;
+            border-color: #8cc2dd;
+            box-shadow: 0 2px 8px rgba(140, 194, 221, 0.08);
+            background: transparent;
         }
         .search-result-title {
             color: #eee;

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -461,13 +461,12 @@
                                         .join("") +
                                     "</div>";
                             }
-                            const baseUrl = item.url || `${window.location.origin}/${item.slug}`;
-                            const url = baseUrl + (baseUrl.indexOf("?") === -1 ? "?" : "&") + "ref=search";
+                            const url = item.url || `${window.location.origin}/${item.slug}`;
                             html +=
                                 '<div class="search-result-item">' +
                                 '<a href="' +
                                 escapeHtml(url) +
-                                '" class="search-result-link" tabindex="0">' +
+                                '" class="search-result-link" data-umami-event="search-click" data-umami-event-title="' + escapeHtml(item.title || "") + '" tabindex="0">' +
                                 '<div class="search-result-title">' +
                                 escapeHtml(item.title || "") +
                                 "</div>" +

--- a/layouts/til/single.html
+++ b/layouts/til/single.html
@@ -28,6 +28,7 @@
   {{ end }}
 </div>
 
+{{ partial "related-posts.html" . }}
 {{ partial "sidebar.html" . }}
 {{ partial "comments.html" . }}
 {{ partial "newsletter.html" . }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a client-side Related Posts section on blog and TIL pages and refresh search results with card-style items and a scrollable list. Adds Umami click tracking on related and search links, removes `ref` query params, and hardens links with date validation and a strict URL protocol allowlist.

- **New Features**
  - Renders via `layouts/partials/related-posts.html` on blog and TIL pages.
  - Fetches from `/api/related?limit=5&url=<current>`; shows title, date, and up to 3 tags (tags open in a new tab with dedicated styles).
  - Card UI with decoupled link styles; supports light/dark; shows a spinner; hides on empty/error; aborts fetch on navigation.
  - Search: card-style results with hover/box-shadow in a scrollable container.

- **Migration**
  - Provide a `/api/related` endpoint returning `{ success, data: { items: [{ title, url?, slug?, publishedAt?, tags? }] } }`.
  - Include an absolute `url` or a valid `slug`; handle CORS if cross-origin.

<sup>Written for commit ca29954d0fabf9b89afbaabc3862cdbc7602eb92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

